### PR TITLE
Tupperbox and other community updates

### DIFF
--- a/js/index.ts
+++ b/js/index.ts
@@ -4,4 +4,3 @@ import { definitionsFromContext } from "stimulus/webpack-helpers"
 const application = Application.start()
 const context = require.context("./controllers", true, /\.ts$/)
 application.load(definitionsFromContext(context))
-

--- a/src/_community/code-of-conduct.md
+++ b/src/_community/code-of-conduct.md
@@ -58,6 +58,7 @@ Examples of unacceptable behavior include:
 * Intentionally dead-naming or misgendering others
 * Publishing others' private information, such as a physical or email address, without their explicit permission
   ("doxxing")
+* Gatekeeping others' access to mental health or accessibility tools
 * Advocating for, or encouraging, any unacceptable forms of behaviour
 * Other conduct which could reasonably be considered inappropriate
 
@@ -85,8 +86,9 @@ this Code of Conduct when community members violate it in spaces not managed by 
 ## Reporting a Problem
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the Quilt community team 
-directly on Discord. If your report concerns a specific community team member or group of community team members, 
-please send your report to a team member that is not part of the report, or a member of the administrative board.
+directly on Discord, either via private message or the ModMail bot. If your report concerns a specific community team 
+member or group of community team members, please send your report to a team member that is not part of the report, or 
+a member of the administrative board.
 
 All complaints will be reviewed and investigated promptly and fairly, and all team members are obligated to respect the
 privacy and security of the reporter of any incident.

--- a/src/_community/index.md
+++ b/src/_community/index.md
@@ -11,5 +11,5 @@ You can find the Quilt in the following places.
 - Our [GitHub organization](https://github.com/{{ site.github_username }})
 
 In all of these places you are expected to follow our [rules]({% link _community/rules.md %})
-and [code of conduct]({% link _community/code-of-conduct.md %}).
+and [Code of Conduct]({% link _community/code-of-conduct.md %}).
 

--- a/src/_community/moderation.md
+++ b/src/_community/moderation.md
@@ -39,6 +39,12 @@ quality of life for the sake of the Quilt community.
 
 ## Our Hierarchy
 
+{% admonition %}
+**Note:** All community team members can act as moderators, regardless of their named role. That said, Community
+Moderators are the people you should contact first if there's a problem - Community Managers should be contacted
+only when Community Moderators are unavailable, or when your concerns relate to a Community Moderator.
+{% endadmonition %}
+
 While all community team members have equal influence, there are two primary roles:
 
 * **Community Moderators** are responsible for maintaining the safety and welfare of our community members, by 
@@ -48,33 +54,26 @@ While all community team members have equal influence, there are two primary rol
   and supporting the community team, maintaining community spaces and automations, and keeping everything running
   smoothly. If you have concerns about how the community is run, these are the people you should contact first.
 
-**Note:** All community team members can act as moderators, regardless of their named role. That said, Community
-Moderators are the people you should contact first if there's a problem - Community Managers should be contacted
-only when Community Moderators are unavailable, or when your concerns relate to a Community Moderator. 
-
 For more information on how the community team is structured and what processes it follows, please read 
 [RFC 7: Community Team](https://github.com/QuiltMC/rfcs/blob/master/rfc/0007-community-team.md).
 
 ## Discord Moderation Tools
 
-We currently have a fairly lightweight set of tools for moderation, provided by [CarlBot](https://carl.gg/). This bot
-provides a set of standard moderation commands, as well as some lightweight automations. Additionally, we make use of
-[CrossLink](https://panleyent.com/crosslink/) to automatically vet and remove links and attachments that are known
-to be problematic or contain viruses.
+We currently have a fairly lightweight set of tools for moderation, provided by [Zeppelin](https://zeppelin.gg/). This 
+bot provides a set of standard moderation commands, as well as some lightweight automations. Additionally, we make use 
+of [CrossLink](https://panleyent.com/crosslink/) to automatically vet and remove links and attachments that are known
+to be problematic or contain viruses, and a [ModMail bot](https://github.com/kyb3r/modmail) to allow users to contact
+the community team if they need anything.
 
-When issuing infractions, community team members **must** use the CarlBot's commands. The prefix is `!`, and community 
-team members can look at the `!help`for the `warn`, `mute`, `kick`, `tempban` and `ban` commands for more information 
-on how they work.
+When issuing infractions, community team members **must** use Zeppelin's commands. The prefix is `!!`, and community 
+team members can look at [the Zeppelin site](https://zeppelin.gg/docs/plugins/mod_actions/usage) for more information 
+on how these commands work.
 
-There are some other useful commands too, such as `purge` and `lock` - team members should familiarize themselves with 
-CarlBot's list of commands as soon as they can.
+There are some other useful commands too, such as `clean` and `search` - team members should familiarize themselves 
+with Zeppelin's full list of commands as soon as they can.
 
-{% comment %}
-NOTE: If we decide to add PK, it should be mentioned here.
-
-We also ask that team members familiarize themselves with [PluralKit](https://pluralkit.me/), as there are several 
-plural systems present in our community that make use of it.
-{% endcomment %}
+We also ask that team members familiarize themselves with [Tupperbox](https://github.com/Runi-c/Tupperbox), as there 
+are several people present in our community that make use of it. 
 
 ## Discord Infraction Policy
 

--- a/src/_community/rules.md
+++ b/src/_community/rules.md
@@ -149,9 +149,11 @@ emoji, the advertising of sketchy or NSFW websites, or hateful sentiment.
 ### Reporting
 
 To report rule-breaking behaviour on Discord, mention the **@Moderators** role directly in the channel, and a community 
-team member will be along as soon as they can be. Alternatively, you can send a private message directly to any 
-community team member, or otherwise contact the community team using the relevant contact methods for the given 
-community space.
+team member will be along as soon as they can be. You can also send a private message to the **@ModMail** bot, which
+will open a thread that any currently available community team member can respond to.
+
+Alternatively, you can send a private message directly to any community team member, or otherwise contact the community
+team using the relevant contact methods for the given community space.
 
 If your report concerns a community team member, please send a private message directly to a different 
 member of the community team or a member of the administrative board. All private reports will be treated with 

--- a/src/_community/tupperbox.md
+++ b/src/_community/tupperbox.md
@@ -36,7 +36,7 @@ No commands are available by default.
 ## Applying for Access
 
 If you'd like to make use of Tupperbox, you'll need to ask to be given the **Tupperbox Access** role. You can do this
-by simply sending a private message to the `@ModMail` bot, stating that you'd like to use Tupperbox and providing a
+by simply sending a private message to the **@ModMail** bot, stating that you'd like to use Tupperbox and providing a
 short description of why you'd like to use it.
 
 That's all there is to it - once a moderator has a chance to address your message, you'll be given the role!

--- a/src/_community/tupperbox.md
+++ b/src/_community/tupperbox.md
@@ -1,0 +1,117 @@
+---
+title: Tupperbox
+---
+
+{% admonition %}
+**Note:** This document is specific to Discord. If you're not making use of our community spaces on Discord, Tupperbox
+won't be available.
+{% endadmonition %}
+
+[Tupperbox](https://github.com/Runi-c/Tupperbox) is a Discord bot that exists to allow users to proxy their messages
+via Discord webhooks. This has many practical applications, especially given that Discord doesn't have any features
+that support the plural community, or any built-in mental health aids.
+
+Tupperbox has many fun and interesting uses for all kinds of situations, but in Quilt community spaces it should only 
+be used for [plurality](#plurality) or self-identity purposes, or as a mental health aid. We do not allow users to make use of 
+Tupperbox for role-playing.
+
+If you see users talking with the bot tag, they're talking through Tupperbox. You can react to any message sent this
+way with the `question` emote (❓) for information on which Discord account the message belongs to.
+
+## General Usage
+
+The primary function of Tupperbox is automatically proxying messages that people using it send, in order to make those
+messages appear to come from someone else. This is done by making use of Discord webhooks - which has the unfortunate
+side effect of Discord stating that the messages were sent by a bot. Rest assured that this isn't the case - while the
+messages were proxied by Tupperbox, they were written by another member of the community
+
+As a member of the community, there's only one Tupperbox feature available to you by default - the ability to figure 
+out which Discord account was used to send a proxied message. You can do this by reacting to any proxied message using
+the `question` emote (❓), which will cause Tupperbox to send you a private message like the following:
+
+> That proxy was sent by [@user](#) (tag: user#0000 - id: 000000000000000000).
+
+No commands are available by default.
+
+## Applying for Access
+
+If you'd like to make use of Tupperbox, you'll need to ask to be given the **Tupperbox Access** role. You can do this
+by simply sending a private message to the `@ModMail` bot, stating that you'd like to use Tupperbox and providing a
+short description of why you'd like to use it.
+
+That's all there is to it - once a moderator has a chance to address your message, you'll be given the role!
+
+Once you have access to Tupperbox, you'll also be granted access to the `#tupperbox-posting` channel - this channel
+exists to allow you to make use of the Tupperbox commands somewhere that isn't visible to other community members. Feel
+free to use `tul!help` here for information on how to work with Tupperbox.
+
+## Moving from PluralKit
+
+If you already have a system set up on PluralKit, you can easily import that system to Tupperbox. Simply follow these
+steps:
+
+1. Send a private message to PluralKit: `pk;export`
+2. Copy the link that PluralKit gives you, to use in the next step
+3. Send a private message to Tupperbox: `tul!import LINK`
+
+## Moderation Notes
+
+When working with Tupperbox, please note that our moderation policy is one of system accountability, meaning that
+[plural systems](#plurality) are responsible for their members. Unfortunately, there's no practical way to moderate
+system members individually - the community team is only able to target the Discord account you're using when acting
+as moderators.
+
+If you're part of a plural system, we suggest that you talk with the other members of your system and make sure they're
+aware of this.
+
+---
+
+## Plurality?
+
+{% admonition %}
+**Note:** Pluralities are not the only valid reason to make use of a tool like Tupperbox, but it's by far the most 
+common use for it in our community spaces - so we created this section to help explain the concept. Any gatekeeping of
+these types of tools will not be tolerated in Quilt community spaces, but you're always welcome to contact a member of 
+the community team directly if you have any concerns.
+{% endadmonition %}
+
+Plurality is the concept of multiple people sharing a single body, inhabiting the same brain. Many people's first
+(or only) experience with this is from people with Dissociative Identity Disorder (DID), but there are many other
+situations that can cause something like this to happen - and in many cases, **the existence of a plurality is not
+problematic or negative**. As [More Than One](https://morethanone.info/) states:
+
+> Plurality (or multiplicity) is the existence of multiple self-aware entities inside one physical brain.
+> 
+> You could think of a plural collective as a group of lifelong roommates, but with a body instead of an apartment.
+
+In general, this group of entities tends to be known as a **plural system**.
+
+When interacting with plural people, remember to treat each individual member of a plural system with respect. Don't
+ask to meet the "real" person and don't suggest that they need to be "cured" - instead, treat each member as separate
+people, with their own memories, experiences and personality. If they ask you to treat them in a specific way, listen
+to them and follow their lead as best you can - after all, every system is different.
+
+For more information on plurality, feel free to browse the following resources...
+
+### Ex Uno Plures
+
+{% admonition %}
+**Note:** This site belongs to a specific plural system, and much of what's written there is related to their personal
+experiences of plurality. Additionally, some articles there were written quite some time ago, and may contain vulgar
+language and outdated terminology - including terms that exist outside the plural community. Nonetheless, it remains 
+a popular and useful resource for people approaching plurality and plural systems from the outside.
+{% endadmonition %}
+
+* [Fictive Identities](https://www.exunoplures.org/main/fictive-identities/) by Noël Dawkins
+* [Plurality for Skeptics](https://www.exunoplures.org/main/articles/skeptics/) by Em Flynn
+* [Rules of Engagement: Plural Etiquette](https://www.exunoplures.org/main/articles/rules/) by Em Flynn, Hess Sakal 
+  and Kerry Dawkins
+  
+### Other Resources
+
+* [Cerberus Plural](https://cerberusplural.com/), the plural news and media watchdog
+* [More Than One](https://morethanone.info/), a quick, easy-to-digest overview of plurality - including information on etiquette and myths
+* [r/plural Plurality FAQ](https://www.reddit.com/r/plural/wiki/faqs)
+* [Resource Links from Plurality Resource](https://pluralityresource.org/affiliates/)
+
+*[DID]: Dissociative Identity Disorder

--- a/src/_community/tupperbox.md
+++ b/src/_community/tupperbox.md
@@ -87,9 +87,14 @@ problematic or negative**. As [More Than One](https://morethanone.info/) states:
 In general, this group of entities tends to be known as a **plural system**.
 
 When interacting with plural people, remember to treat each individual member of a plural system with respect. Don't
-ask to meet the "real" person and don't suggest that they need to be "cured" - instead, treat each member as separate
-people, with their own memories, experiences and personality. If they ask you to treat them in a specific way, listen
-to them and follow their lead as best you can - after all, every system is different.
+pathologise their identity (for example, by asking to meet the "real" person or suggesting that they need to be 
+"cured"), and remember that many plural people consider their identity more a matter of philosophy than of medicine. 
+Additionally, treat each system member as separate people, with their own memories, experiences and personality - If 
+they ask you to treat them in a specific way, listen to them and follow their lead as best you can.
+
+It's also worth noting that plurality is a whole world and plural systems often greatly differ from each other,
+sometimes identifying or manifesting themselves in completely different ways. All plural systems are valid, regardless
+of how their members identify or interact, how they were formed, or how they think about themselves.
 
 For more information on plurality, feel free to browse the following resources...
 
@@ -113,5 +118,3 @@ a popular and useful resource for people approaching plurality and plural system
 * [More Than One](https://morethanone.info/), a quick, easy-to-digest overview of plurality - including information on etiquette and myths
 * [r/plural Plurality FAQ](https://www.reddit.com/r/plural/wiki/faqs)
 * [Resource Links from Plurality Resource](https://pluralityresource.org/affiliates/)
-
-*[DID]: Dissociative Identity Disorder

--- a/src/_layouts/base.html
+++ b/src/_layouts/base.html
@@ -27,6 +27,7 @@
         {% feed_meta %}
 
         <script src="https://kit.fontawesome.com/b1b70f724e.js" crossorigin="anonymous"></script>
+        <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
     </head>
     {% comment %}
     preload class stops CSS animations from playing during page load and is removed by JS
@@ -91,10 +92,13 @@
         {% if page.js %}
         <script src="/assets/js/bundle.js"></script>
         {% endif %}
+
         <script>
             document.addEventListener('DOMContentLoaded', function() {
                 document.body.className = document.body.className.replace("preload", "")
             });
+
+            twemoji.parse(document.body);
         </script>
     </body>
 </html>

--- a/src/_plugins/admonitions.rb
+++ b/src/_plugins/admonitions.rb
@@ -1,0 +1,13 @@
+module Jekyll
+  class AdmonitionBlock < Liquid::Block
+    def render(context)
+      text = super
+      site = context.registers[:site]
+      converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+
+      "<div class='admonition'>#{converter.convert(text)}</div>"
+    end
+  end
+end
+
+Liquid::Template.register_tag('admonition', Jekyll::AdmonitionBlock)

--- a/src/_sass/admonitions.scss
+++ b/src/_sass/admonitions.scss
@@ -1,9 +1,7 @@
 // Admonitions or message blocks, indented content within another block of content
 
 div.admonition {
-  background-color: $block-color;
-  border-radius: 6px;
-  box-shadow: 1px 2px 2px $shadow-color inset;
+  @extend .block;
 
   margin-bottom: 1rem;
   margin-top: 1rem;

--- a/src/_sass/admonitions.scss
+++ b/src/_sass/admonitions.scss
@@ -1,0 +1,11 @@
+// Admonitions or message blocks, indented content within another block of content
+
+div.admonition {
+  background-color: $block-color;
+  border-radius: 6px;
+  box-shadow: 1px 2px 2px $shadow-color inset;
+
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+  padding: 0.1rem 1rem;
+}

--- a/src/_sass/block.scss
+++ b/src/_sass/block.scss
@@ -4,8 +4,6 @@
     background-color: $block-color;
     box-shadow: 1px 2px 2px $shadow-color inset;
     border-radius: 6px;
-
-    background-color: $block-color;
 }
 
 // styles both highlight figures and ```foo```
@@ -27,3 +25,13 @@ p code {
 
 @import "syntax.scss";
 
+// blockquote blocks
+
+blockquote {
+    border-left: 3px solid $base-darker;
+    color: $base-darker;
+    font-style: italic;
+
+    margin: 1rem 1rem 1rem 0;
+    padding-left: 1rem;
+}

--- a/src/_sass/text.scss
+++ b/src/_sass/text.scss
@@ -20,4 +20,7 @@ a {
 a:hover, a:focus { color: adjust-color($link, $lightness: -10%); }
 a:active { color: adjust-color($link, $lightness: -15%); }
 
-
+.emoji {
+    height: 1rem;
+    margin-bottom: -0.15rem;
+}

--- a/src/_sass/vars.scss
+++ b/src/_sass/vars.scss
@@ -56,4 +56,4 @@ $blue: #81E3FF;
 $orange: #E6A422;
 
 $base: #cecece;
-$base-darker: darken($base, 20);
+$base-darker: adjust-color($base, $lightness: -20);

--- a/src/_sass/vars.scss
+++ b/src/_sass/vars.scss
@@ -56,4 +56,4 @@ $blue: #81E3FF;
 $orange: #E6A422;
 
 $base: #cecece;
-
+$base-darker: darken($base, 20);

--- a/src/assets/css/style.scss
+++ b/src/assets/css/style.scss
@@ -6,6 +6,7 @@
 
 @import "vars";
 
+@import "admonitions";
 @import "body";
 @import "text";
 @import "block";


### PR DESCRIPTION
This PR contains the following:

* A page with documentation on Tupperbox, how to use it and apply for it, and a plurality primer
* Updates to various community documents that didn't mention ModMail, Zeppelin or Tupperbox, or were otherwise incorrect
* An additional example of unacceptable behaviour for the Code of Conduct: `Gatekeeping others' access to mental health or accessibility tools`
* An `admonition` tag for, well, admonitions: ![image](https://user-images.githubusercontent.com/204153/116811696-6bd14480-ab42-11eb-8862-9f474040606a.png)
* Styling for blockquotes
* Twemoji support, for styling emojis in documents to match Discord's style

[Rendered view for the new Tupperbox page](https://user-images.githubusercontent.com/204153/116818687-98965380-ab64-11eb-9182-43d6cecb78f9.png)
