### PR TITLE
Add Minecraft Patchnote Viewer to quiltmc.org

### DIFF
--- a/src/mc-patchnotes.html
+++ b/src/mc-patchnotes.html
@@ -11,6 +11,7 @@ layout: base
                 <h1>Versions</h1>
             </nav>
             <main>
+                <noscript>You need to enable JavaScript for this website in order to function.</noscript>
                 <h1 id="title">Minecraft Patchnotes</h1>
                 <img id="image" style="float: right; border-radius: 10px; margin: 10px;"/>
                 <div id="body">

--- a/src/mc-patchnotes.html
+++ b/src/mc-patchnotes.html
@@ -1,0 +1,49 @@
+---
+title: Minecraft Patchnotes
+permalink: /mc-patchnotes/
+layout: base
+---
+
+<div class="content">
+    <div class="container">
+        <div class="sidebar-container">
+            <nav class="sidebar" id="sidebar">
+                <h1>Versions</h1>
+            </nav>
+            <main>
+                <h1 id="title">Minecraft Patchnotes</h1>
+                <img id="image" style="float: right; border-radius: 10px; margin: 10px;"/>
+                <div id="body"></div>
+            </main>
+        </div>
+    </div>
+</div>
+
+<script>
+    fetch("https://launchercontent.mojang.com/javaPatchNotes.json")
+        .then(response => response.json())
+        .then(data => {
+            // Render body
+            refresh = () => {
+                var version = window.location.hash.substr(1);
+                var entry = data.entries.find(e => e.version == version);
+                if (entry) {
+                    document.getElementById("title").innerText = entry.title;
+                    document.getElementById("body").innerHTML = entry.body;
+                    document.getElementById("image").setAttribute("src", "https://launchercontent.mojang.com" + entry.image.url);
+                }
+            };
+
+            // Create nav-links
+            data.entries.forEach(entry => {
+                var version = window.location.hash.substr(1);
+                var newRef = document.createElement("a");
+                newRef.innerText = entry.version;
+                newRef.setAttribute("href", "/mc-patchnotes/#" + entry.version);
+                document.getElementById("sidebar").appendChild(newRef);
+            });
+
+            window.onhashchange = refresh;
+            refresh();
+        });
+</script>

--- a/src/mc-patchnotes.html
+++ b/src/mc-patchnotes.html
@@ -13,21 +13,26 @@ layout: base
             <main>
                 <h1 id="title">Minecraft Patchnotes</h1>
                 <img id="image" style="float: right; border-radius: 10px; margin: 10px;"/>
-                <div id="body"></div>
+                <div id="body">
+                    Select the specific version from the sidebar.
+                </div>
             </main>
         </div>
     </div>
 </div>
 
 <script>
+    // Fetch launcher metadata
     fetch("https://launchercontent.mojang.com/javaPatchNotes.json")
         .then(response => response.json())
         .then(data => {
-            // Render body
-            refresh = () => {
+            // Render patchnotes
+            render = () => {
+                // Read the version from the anchor and look it up in the json
                 var version = window.location.hash.substr(1);
                 var entry = data.entries.find(e => e.version == version);
                 if (entry) {
+                    // Replace title, body and image url wtih the selected version
                     document.getElementById("title").innerText = entry.title;
                     document.getElementById("body").innerHTML = entry.body;
                     document.getElementById("image").setAttribute("src", "https://launchercontent.mojang.com" + entry.image.url);
@@ -39,11 +44,12 @@ layout: base
                 var version = window.location.hash.substr(1);
                 var newRef = document.createElement("a");
                 newRef.innerText = entry.version;
-                newRef.setAttribute("href", "/mc-patchnotes/#" + entry.version);
+                newRef.setAttribute("href", window.location.pathname + "#" + entry.version);
                 document.getElementById("sidebar").appendChild(newRef);
             });
 
-            window.onhashchange = refresh;
-            refresh();
+            // Rerender the patchnote when the url changes
+            window.onhashchange = render;
+            render();
         });
 </script>

--- a/src/mc-patchnotes.html
+++ b/src/mc-patchnotes.html
@@ -11,7 +11,10 @@ layout: base
                 <h1>Versions</h1>
             </nav>
             <main>
-                <noscript>You need to enable JavaScript for this website in order to function.</noscript>
+                <noscript>
+                    This page requires JavaScript to retrieve the Minecraft launcher's patch notes.
+                    Please enable it and reload the page to continue.
+                </noscript>
                 <h1 id="title">Minecraft Patchnotes</h1>
                 <img id="image" style="float: right; border-radius: 10px; margin: 10px;"/>
                 <div id="body">


### PR DESCRIPTION
Right now, there is no easy to access website to list Minecraft patchnotes.
While minecraft.net does post patch notes, there is no easy way to differentiate those posts from other news. Additionally, their website caching can make it hard to get fast updates.
For this reason, the cozy-discord bot already switched to using the Minecraft launcher metadata. This works well, however due to limitations on discord embeds (and the reasonable argument that the message would just be too long), the bot only displays the first few lines of the patchnotes.

This PR adds a site to quiltmc.org that dynamically fetches and renders the metadata used by the Minecraft launcher.
This is intended as a link target for the discord bot so people can have easy access to the full patchnotes.
It is not necessary to update the website for new versions, as the content is pulled and rendered using javascript.

The launcher metadata can be found here: https://launchercontent.mojang.com/javaPatchNotes.json

Please keep in mind that I'm not a web developer and hardly know any best practices.
Let me know what I did wrong (e.g. the inline style) and how to fix it!