### PR TITLE
Correct the spelling of Chasm

### DIFF
--- a/src/_about/faq-devs.md
+++ b/src/_about/faq-devs.md
@@ -31,7 +31,7 @@ For developers, Quilt provides the following advantages over Fabric:
   you're using a different set of mappings
 * A more community-oriented approach that ensures that everyone's voice is heard when raising issues and opinions,
   regardless of how prolific a developer is, or how well-known they are
-* **Future goal:** A new Collision Handling ASM backend (CHASM) which acts as the backbone for our mixin and access 
+* **Future goal:** A new Collision Handling ASM backend (Chasm) which acts as the backbone for our mixin and access 
   widener implementations, allowing those and other bytecode manipulation tools to function without any special handling
   required in Quilt's build tools or loader, and helping mods to remain compatible with each other
 
@@ -67,7 +67,7 @@ a name.
 We plan on trying to make this transition as painless as possible -- by matching Fabric's API surface, allowing you to
 stick with Yarn mappings if you'd like, and providing support for developers that are porting their mods. It's worth
 noting that -- as of this writing -- Fabric mods that contain mixin plugins (for example, for conditional mixins)  are 
-supported by Quilt's backwards-compatibility efforts, but this will not be the case once [CHASM](#CHASM) has been 
+supported by Quilt's backwards-compatibility efforts, but this will not be the case once [Chasm](#Chasm) has been 
 added to the toolchain. Quilt will provide an alternative approach with proper toolchain support later on -- and we'll 
 help you figure out how to move to it if you need support.
 
@@ -94,15 +94,15 @@ We'll be working on docs throughout the beta period and beyond, so please keep a
 {% endadmonition %}
 {% admonition %}
 
-## What the heck is CHASM, exactly? {#CHASM}
+## What the heck is Chasm, exactly? {#Chasm}
 
-CHASM is short for **_Collision Handling ASM_**. CHASM is a bytecode transformation library, acting as a backend that's
+Chasm is short for **_Collision Handling ASM_**. Chasm is a bytecode transformation library, acting as a backend that's
 intended for use via separate frontends, rather than for mods to use directly. It intends to provide a safer way to
 modify bytecode at runtime, handling collisions automatically and trying to help mods to stay compatible.
 
-Frontends for use with CHASM will include Access Wideners and, of course, Mixin. However, there's no reason additional
+Frontends for use with Chasm will include Access Wideners and, of course, Mixin. However, there's no reason additional
 frontends couldn't be written -- by Quilt, or by the community.
 
-CHASM has not yet been implemented, but we're working on it!
+Chasm has not yet been implemented, but we're working on it!
 
 {% endadmonition %}

--- a/src/_about/newcomer-guide.md
+++ b/src/_about/newcomer-guide.md
@@ -82,7 +82,7 @@ The following improvements are also planned for a full release:
   released -- Hashed Mojmap, unlike MCP and Intermediary, never requires human intervention to be released
 * A new Gradle-based toolchain that replaces the existing one, which is currently based on Quilt's fork of Fabric's
   Loom
-* The CHASM project, which will provide safer tooling for working with Java bytecode; acting as the backend for our
+* The Chasm project, which will provide safer tooling for working with Java bytecode; acting as the backend for our
   Mixin implementation, but also allowing developers to easily add their own bytecode-manipulation tools -- This is a
   project with implications far wider than just the modding community, and we're very excited about it!
 

--- a/src/_about/teams.md
+++ b/src/_about/teams.md
@@ -131,14 +131,14 @@ compilation tooling and build system plugins. This team is responsible for the f
     {% include team/glitch.liquid %}
 </div>
 
-## CHASM
+## Chasm
 
-The CHASM team is responsible for maintaining CHASM, the Collision Handling ASM toolset. CHASM aims to provide a safer
+The Chasm team is responsible for maintaining Chasm, the Collision Handling ASM toolset. Chasm aims to provide a safer
 backend for modifying JVM bytecode at runtime, allowing for more compatible mixins and extra bytecode modification 
 frontends. 
 
 **Note:** You may see projects with "ASMR" in the name on the QuiltMC GitHub organisation. This was the old, internal
-codename for CHASM, so those projects are associated with the CHASM team.
+codename for Chasm, so those projects are associated with the CHASM team.
 
 This team is responsible for the following projects:
 

--- a/src/_posts/2022-03-22-quilt-enters-beta.md
+++ b/src/_posts/2022-03-22-quilt-enters-beta.md
@@ -22,7 +22,7 @@ It may be frustrating, but trying different approaches and iterating is an essen
 
 Beta software is also generally missing features that will be included in the full release, and Quilt is no exception. All our projects are at a stage where we feel that they are usable, but most of them are still missing features that will be included in the final release. Namely:
 - Mods will be built using a fork of Fabric's Loom with Intermediary, instead of Quilt-Gradle with Hashed MojMap.
-- The CHASM bytecode transformer is not yet ready for use and will not be available.
+- The Chasm bytecode transformer is not yet ready for use and will not be available.
 - Loader plugins will not exist.
 - QSL (Quilt Standard Libraries) will not be automatically downloaded as a dependency.
 - Many QSL Modules will not be available to use.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/44778521/167296265-a48b10a4-5fb1-4df8-aebd-9dede44a2460.png)

This PR updates the spelling from `CHASM` to `Chasm`.