### PR TITLE
Fix external usage links

### DIFF
--- a/src/_includes/navbar.liquid
+++ b/src/_includes/navbar.liquid
@@ -66,11 +66,11 @@
                     {% for p in usage_pages %}
                         {% include nav_link.liquid text=p.title href=p.url subpage=false %}
                     {% endfor %}
+
+                    <div class="divider"> External Links </div>
+
+                    {% include nav_link.liquid text="Quilt Import Utility" href="https://lambdaurora.dev/tools/import_quilt.html" subpage=false %}
                 </div>
-
-                <div class="divider"> External Links </div>
-
-                {% include nav_link.liquid text="Quilt Import Utility" href="https://lambdaurora.dev/tools/import_quilt.html" subpage=false %}
             </div>
 
             <div class="navbar-item has-dropdown is-hoverable">


### PR DESCRIPTION
This PR fixes the following issue:
![broken external usage links](https://user-images.githubusercontent.com/37983572/168481302-0c2b6446-2321-4c0f-8e8e-b9744099e199.png)
by moving the divider and link inside the dropdown menu.