### PR TITLE
chore: improve curseforge install page by mentioning jumpquilt

### DIFF
--- a/src/install/curseforge.md
+++ b/src/install/curseforge.md
@@ -14,7 +14,6 @@ Thanks to Claycorp, RedBlue and Yamza for their help, as well as to everyone tha
 [CurseForge Ideas suggestion](https://curseforge-ideas.overwolf.com/ideas/CF-I-2662). We couldn't have gotten this far 
 without you!
 
-# Manual Installation
+# Workaround
 
-It is not currently possible to manually install Quilt into a CurseForge instance. Please show your support on the
-suggestion linked above if you'd like to see CurseForge adding Quilt to their services!
+As a workaround to use Quilt in CurseForge modpacks or in their launcher, you can create a Forge profile where you install [JumpQuilt](https://www.curseforge.com/minecraft/mc-mods/jumpquilt), which is a mod that hijacks the launching process so that Quilt is loaded instead of Forge.

--- a/src/install/gdlauncher.md
+++ b/src/install/gdlauncher.md
@@ -6,13 +6,12 @@ permalink: /install/gdlauncher/
 
 # GDLauncher <a href="https://gdevs.io" class="button is-link is-pulled-right"><span class="icon"><i class="fas fa-globe"></i></span><span>Website</span></a>
 
-### Status: Pending Discussion
+### Status: Work In Progress
 
-GDLauncher does not currently support Quilt, but we've 
-[opened a GitHub issue](https://github.com/gorilla-devs/GDLauncher/issues/1308) to ask about having Quilt support added.
-If you're interested in seeing Quilt support in GDLauncher, feel free to take a look at that issue.
+GDLauncher does not currently support Quilt, but a member of the community has 
+[submitted a pull request](https://github.com/gorilla-devs/GDLauncher/pull/1400) that adds Quilt support. If you're 
+interested in seeing Quilt support in GDLauncher, feel free to take a look at that PR.
 
-# Manual Installation
+# Workaround
 
-At the moment, we don't know whether it's possible to manually install Quilt using GDLauncher. If you have any
-information on this, please let us know!
+As a workaround to use Quilt in GDLauncher until the pull request is finished and merged you can create a Forge profile where you install [JumpQuilt](https://www.curseforge.com/minecraft/mc-mods/jumpquilt), which is a mod that hijacks the launching process so that Quilt is loaded instead of Forge.


### PR DESCRIPTION
also improves gdlauncher's page by mentioning the pr and jumpquilt as a workaround