### PR TITLE
Fix untranslated strings on some pages

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -15,9 +15,9 @@ const content = Astro.props.content as BaseProps;
 // extract locale from URL
 const match = (Astro.url.pathname + "/").match(/^\/([\w-]+)\//);
 if (match && i18next.languages.includes(match[1])) {
-	i18next.changeLanguage(match[1]);
+	await i18next.changeLanguage(match[1]);
 } else {
-	i18next.changeLanguage("en");
+	await i18next.changeLanguage("en");
 }
 ---
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,6 +1,10 @@
 ---
 import Base from "@layouts/Base.astro";
-import { t } from "i18next";
+import i18next, { t } from "i18next";
+
+// FIXME(leah@pluie): there is only one 404 page, so no i18n on the 404 page for us
+// unless we figure something out
+await i18next.changeLanguage("en");
 ---
 
 <style type="text/css" media="screen">


### PR DESCRIPTION
Turns out, `await`ing on `i18next.changeLanguage` does the job...