### PR TITLE
Make the highlight inside code blocks visible

### DIFF
--- a/public/assets/prism-material-dark.css
+++ b/public/assets/prism-material-dark.css
@@ -25,14 +25,14 @@ code[class*="language-"]::-moz-selection,
 pre[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection,
 pre[class*="language-"] ::-moz-selection {
-	background: #363636;
+	background: #003c8f;
 }
 
 code[class*="language-"]::selection,
 pre[class*="language-"]::selection,
 code[class*="language-"] ::selection,
 pre[class*="language-"] ::selection {
-	background: #363636;
+	background: #003c8f;
 }
 
 :not(pre) > code[class*="language-"] {


### PR DESCRIPTION
The original color was too similar to the background, making it seem like nothing changed at all; This PR changes that;
Here's how the new color looks like:
![image](https://user-images.githubusercontent.com/85590273/190480312-b2995414-77a2-485f-b940-15404d0f02e3.png)
