### PR TITLE
Add an RSS feed (#70)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
 		"rollup": "^2.79.1",
 		"sass": "^1.55.0",
 		"typescript": "^4.8.4"
+	},
+	"dependencies": {
+		"@astrojs/rss": "^1.0.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,6 +3,7 @@ lockfileVersion: 5.4
 specifiers:
   '@astrojs/markdown-component': ^1.0.1
   '@astrojs/mdx': ^0.11.2
+  '@astrojs/rss': ^1.0.2
   '@astrojs/sitemap': ^1.0.0
   '@creativebulma/bulma-divider': ^1.1.0
   '@creativebulma/bulma-tooltip': ^1.2.0
@@ -27,6 +28,9 @@ specifiers:
   rollup: ^2.79.1
   sass: ^1.55.0
   typescript: ^4.8.4
+
+dependencies:
+  '@astrojs/rss': 1.0.2
 
 devDependencies:
   '@astrojs/markdown-component': 1.0.1
@@ -170,6 +174,12 @@ packages:
     dependencies:
       prismjs: 1.29.0
     dev: true
+
+  /@astrojs/rss/1.0.2:
+    resolution: {integrity: sha512-WPMW5a3D+nAbuu/i7LANfp1GnVrdnzcsUNrR7o8IvPJXJMjVGtDqdUqNDj20Rj3rwcWbOL2KVvGPMjCqx0tRWQ==}
+    dependencies:
+      fast-xml-parser: 4.0.11
+    dev: false
 
   /@astrojs/sitemap/1.0.0:
     resolution: {integrity: sha512-42GxuF5FP7RaKXZrwGLBLOX3hPv+Wl7ExJC43O0J5e34ojJkLeKf7QfwN1UwrJlqH0Ywi0Fm4/xGe482G09+wg==}
@@ -1808,6 +1818,13 @@ packages:
       merge2: 1.4.1
       micromatch: 4.0.5
     dev: true
+
+  /fast-xml-parser/4.0.11:
+    resolution: {integrity: sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==}
+    hasBin: true
+    dependencies:
+      strnum: 1.0.5
+    dev: false
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -3726,6 +3743,10 @@ packages:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
     dev: true
+
+  /strnum/1.0.5:
+    resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
+    dev: false
 
   /style-to-object/0.3.0:
     resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}

--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -1,0 +1,30 @@
+import rss from "@astrojs/rss";
+
+const postImportResult = import.meta.glob("./en/blog/**/*.md", { eager: true });
+const posts = Object.values(postImportResult);
+
+function getExcerptOfCompiledPost(post) {
+	const content = post.compiledContent();
+	return content.slice(0, content.indexOf("<!-- MORE -->"));
+}
+
+// TODO(apple): Multiple feeds, one per language (RSS doesn't support multi-language feeds).
+// That would be too easy.
+export const get = () =>
+	rss({
+		// `<title>` field in output xml
+		title: "The Quilt Project",
+		// `<description>` field in output xml
+		description: "The mod-loader that cares.",
+		// base URL for RSS <item> links
+		site: import.meta.env.SITE,
+		// list of `<item>`s in output xml
+		items: posts.map((post) => ({
+			link: post.url,
+			title: post.frontmatter.title,
+			pubDate: post.frontmatter.date,
+			description: getExcerptOfCompiledPost(post),
+		})),
+		// (optional) inject custom xml
+		customData: `<language>en-us</language>`,
+	});


### PR DESCRIPTION
Closes #70 

Just a really basic feed based on official documentation, but look, it has a description!

![image](https://user-images.githubusercontent.com/20385973/194627982-140bd8d0-44f6-4327-a558-142afc535d7b.png)

Same path as the old feed, because everything already points there.

Preview: https://deploy-preview-76--ecstatic-booth-88897a.netlify.app/feed.xml