### PR TITLE
Add Prism Launcher to the Install page

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "quiltmc-website",
 	"version": "1.0.0",
 	"description": "Website for the Quilt modloader",
-	"packageManager": "pnpm@7.9.0",
+	"packageManager": "pnpm@7.13.5",
 	"scripts": {
 		"dev": "node scripts/preprocess.mjs && astro dev",
 		"start": "node scripts/preprocess.mjs && astro start",

--- a/public/assets/img/launchers/prismlauncher.svg
+++ b/public/assets/img/launchers/prismlauncher.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg width="48" height="48" version="1.1" viewBox="0 0 12.7 12.7" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <title>Prism Launcher Logo</title>
+ <g stroke-width=".26458">
+  <path d="m6.35 6.35" fill="#99cd61"/>
+  <path d="m6.35 0.52917-2.5208 4.3656 2.5208 1.4552 2.5203-1.4552 0.10955-3.0996c-1.1511-0.66459-2.3388-1.2661-2.6298-1.2661z" fill="#df6277"/>
+  <path d="m8.9798 1.7952-2.6298 4.5548 2.5203 1.4552 2.5208-4.3656c-0.14552-0.25205-1.2601-0.97975-2.4112-1.6443z" fill="#fb9168"/>
+  <path d="m11.391 3.4396-5.041 2.9104 2.5203 1.4552 2.7389-1.4552c0-1.3292-0.072554-2.6584-0.21808-2.9104z" fill="#f3db6c"/>
+  <path d="m6.35 6.35v2.9104h5.041c0.14552-0.25205 0.21807-1.5812 0.21808-2.9104h-5.2591z" fill="#7ab392"/>
+  <path d="m6.35 6.35v2.9104l2.6298 1.6443c1.1511-0.66459 2.2657-1.3923 2.4112-1.6443l-5.041-2.9104z" fill="#4b7cbc"/>
+  <path d="m6.35 6.35-2.5208 1.4552 2.5208 4.3656c0.29104 0 1.4787-0.60148 2.6298-1.2661l-2.6298-4.5548z" fill="#6f488c"/>
+  <path d="m3.8292 4.8948-2.5203 4.3656c0.29104 0.5041 4.459 2.9104 5.041 2.9104v-5.8208l-2.5208-1.4552z" fill="#4d3f33"/>
+  <path d="m1.309 3.4396c-0.29104 0.5041-0.29104 5.3167 0 5.8208l5.041-2.9104v-2.9104h-5.041z" fill="#7a573b"/>
+  <path d="m6.35 0.52917c-0.58208-2e-8 -4.75 2.4063-5.041 2.9104l5.041 2.9104v-5.8208z" fill="#99cd61"/>
+ </g>
+ <g transform="matrix(.88 0 0 .88 -10.906 -1.2421)">
+  <g transform="translate(13.26 2.2776)">
+   <path transform="matrix(.96975 0 0 .96975 .1921 .1921)" d="m6.3498 2.9393c-0.34105 0-2.7827 1.4099-2.9532 1.7052l2.9532 5.1157 2.9538-5.1157c-0.17052-0.29535-2.6127-1.7052-2.9538-1.7052z" fill="#fff" stroke-width=".26458"/>
+  </g>
+  <path d="m16.746 6.9737 2.8639 4.9609c0.33073 0 2.6991-1.3672 2.8644-1.6536 0.16536-0.28642 0.16536-3.0209 0-3.3073l-2.8644 1.6536z" fill="#dfdfdf" stroke-width=".26458"/>
+ </g>
+ <path d="m3.8299 4.8948c-0.14551 0.25205-0.14553 2.6584 0 2.9104 0.14553 0.25204 2.2292 1.4552 2.5203 1.4552v-2.9104z" fill="#d6d2d2" stroke-width=".26458"/>
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:title>Prism Launcher Logo</dc:title>
+    <dc:date>19/10/2022</dc:date>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Prism Launcher</dc:title>
+     </cc:Agent>
+    </dc:creator>
+    <dc:contributor>
+     <cc:Agent>
+      <dc:title>AutiOne, Boba, ely, Fulmine, gon sawa, Pankakes, tobimori, Zeke</dc:title>
+     </cc:Agent>
+    </dc:contributor>
+    <dc:source>https://github.com/PrismLauncher/PrismLauncher</dc:source>
+    <dc:rights>
+     <cc:Agent>
+      <dc:title>CC BY-SA 4.0</dc:title>
+     </cc:Agent>
+    </dc:rights>
+    <dc:publisher>
+     <cc:Agent>
+      <dc:title>Prism Launcher</dc:title>
+     </cc:Agent>
+    </dc:publisher>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+</svg>

--- a/src/components/parts/install/Launchers.astro
+++ b/src/components/parts/install/Launchers.astro
@@ -15,6 +15,12 @@ import InstallerButton from "@atoms/InstallerButton.astro";
 	altKey="install:logo-multimc"
 />
 <InstallerButton
+	href="/install/prismlauncher"
+	logo="prismlauncher.svg"
+	titleKey="install:platform-prismlauncher"
+	altKey="install:logo-prismlauncher"
+/>
+<InstallerButton
 	href="/install/technic"
 	logo="technic.svg"
 	titleKey="install:platform-technic"

--- a/src/locales/en/install.flt
+++ b/src/locales/en/install.flt
@@ -1,6 +1,7 @@
 # Proper nouns; you shouldn't need to edit them.
 -atlauncher = ATLauncher
 -multimc = MultiMC
+-prismlauncher = Prism Launcher
 -technic = Technic
 -curseforge = CurseForge
 -gdlauncher = GDLauncher
@@ -9,6 +10,7 @@ platform-client = Client
 platform-server = Server
 platform-atlauncher = {-atlauncher}
 platform-multimc = {-multimc}
+platform-prismlauncher = {-prismlauncher}
 platform-technic = {-technic}
 platform-curseforge = {-curseforge}
 platform-gdlauncher = {-gdlauncher}
@@ -17,6 +19,7 @@ logo-minecraft = Minecraft logo
 logo-java = Java logo
 logo-atlauncher = {-atlauncher} logo
 logo-multimc = {-multimc} logo
+logo-prismlauncher = {-prismlauncher} logo
 logo-technic = Technic Launcher logo
 logo-curseforge = {-curseforge} logo
 logo-gdlauncher = {-gdlauncher} logo

--- a/src/pages/en/install/prismlauncher.md
+++ b/src/pages/en/install/prismlauncher.md
@@ -7,7 +7,7 @@ platformKey: platform-prismlauncher
 website: https://prismlauncher.org
 ---
 
-Prism Launcher is a launcher designed to allow users to easily manage multiple installations of Minecraft at once as well as provide all the power tools that an advanced user would need in order to manage their instances.
+Prism Launcher is designed to allow users to manage multiple installations of Minecraft at once easily, and provide the power tools an advanced user would need.
 
 To set up a Quilt instance, simply follow these steps:
 

--- a/src/pages/en/install/prismlauncher.md
+++ b/src/pages/en/install/prismlauncher.md
@@ -1,0 +1,35 @@
+---
+title: "Install: Prism Launcher"
+permalink: /install/prismlauncher/
+
+layout: /src/layouts/InstallPage.astro
+platformKey: platform-prismlauncher
+website: https://prismlauncher.org
+---
+
+Prism Launcher is a launcher designed to allow users to easily manage multiple installations of Minecraft at once as well as provide all the power tools that an advanced user would need in order to manage their instances.
+
+To set up a Quilt instance, simply follow these steps:
+
+1. Download and install Prism Launcher from [their website](https://prismlauncher.org)
+2. Open Prism Launcher, follow the setup steps and click on the **Add Instance** button at the top of the window
+3. Fill out the **Name** box as required (you may also fill the **Group** box optionally)
+4. Select **Vanilla** from the list on the left, and pick the version of Minecraft you'd like to use for your instance
+5. Under the **Mod Loader**, select **Quilt** and then pick the Quilt Loader version you'd like to use.
+6. Click **OK** to create a new Quilt instance
+7. Set up the rest of your instance as normal
+
+That's all there is to it! Once you've followed these steps, your instance should be ready to go -- just add your mods and get playing.
+
+# Installing Mods
+
+To install mods to your Prism Launcher instance, simply follow these steps:
+
+1. Right-click on the instance you'd like to install mods to and select **Edit...**, or click on it once and select **Edit** from the menu on the right of the window
+2. Select **Mods** from the list on the left, and click on the **Download mods** button in the menu on the right side of the window
+3. Click on **Download Mods** on the right side of the window, and use the popup to search for and install the mods you'd like to use.
+4. Ensure you have the **Quilted Fabric API/Quilt Standard Libraries** bundle installed, which you can find [on CurseForge](https://www.curseforge.com/minecraft/mc-mods/qsl) or [on Modrinth](https://modrinth.com/mod/qsl)
+
+If you can't find the mod you'd like to install using the built-in search, you can simply drag-and-drop any mod files you've downloaded into the mod list, and Prism Launcher will ensure it's installed properly.
+
+Start up your game, and the mods should be available immediately. If you run into any issues, please take a look at the [troubleshooting page](/en/usage/troubleshooting), or [join us on Discord](https://discord.quiltmc.org) to ask for support!


### PR DESCRIPTION
Note: This PR is marked as a draft until Prism Launcher has its download page up and ready. Otherwise? It's ready for review!

This PR adds back Prism Launcher to the roster of available launchers for installing Quilt in

[Page preview](https://deploy-preview-80--ecstatic-booth-88897a.netlify.app/en/install/prismlauncher/)