### PR TITLE
Gracefully handle PK private system member lists

### DIFF
--- a/scripts/preprocess.mjs
+++ b/scripts/preprocess.mjs
@@ -102,6 +102,18 @@ async function queryPluralKit() {
 
 	const data = {};
 	for (const [id, response] of responses) {
+		if (!Array.isArray(response)) {
+			// This ensures that private lists are fine but actual errors aren't
+			if (response.code !== 0) {
+				data[id] = [];
+				continue;
+			} else {
+				throw new Error(
+					`queryPluralKit: an attempt to fetch a member list has returned a server error! ${response}`
+				);
+			}
+		}
+
 		// TODO add custom ordering
 		const result = sortBy(response, (mem) => {
 			const date = DateTime.fromISO(mem.created);

--- a/src/components/parts/team/TeamMember.astro
+++ b/src/components/parts/team/TeamMember.astro
@@ -78,7 +78,7 @@ const na = t("team:n-a");
 			</div>
 
 			<div class:list={["system-members", member.description ? "mb-4" : ""]}>
-				{ member.systemMembers === "---"
+				{ member.systemMembers === "---" || getSystemMembers(member.systemMembers).length === 0
 				? <div class="has-tooltip-arrow" data-tooltip={t("team:member-list-redacted")}>
 					<i class="fa-2xl pl-1 fas fa-box-heart"></i>
 				</div>


### PR DESCRIPTION
This PR fixes issues with private system member lists, allowing systems to change their privacy settings at will without halting this website's builds :P

(this means that the `---` value can be obsoleted, but whenever it should be or not should be discussed with the relevant folks)