### PR TITLE
ModMail+ privacy policy

### DIFF
--- a/src/components/setpieces/NavBar.astro
+++ b/src/components/setpieces/NavBar.astro
@@ -123,6 +123,9 @@ const { style = "is-dark" } = Astro.props as Props;
 					>
 						{t("nav-page-staff-resources")}
 					</NavLink>
+					<NavLink href={localizePath("/legal")} icon="fas fa-scale-balanced">
+						{t("nav-page-legal")}
+					</NavLink>
 				</div>
 			</div>
 		</div>

--- a/src/locales/en/common.flt
+++ b/src/locales/en/common.flt
@@ -48,6 +48,7 @@ nav-page-patch-notes = {-patch-notes}
 nav-page-sponsors = {-sponsors}
 nav-page-staff-resources = {-staff-resources}
 nav-page-template-mod = {-template-mod}
+nav-page-legal = Legal
 
 button-close = Close
 button-discord = {-discord}

--- a/src/pages/en/legal/index.mdx
+++ b/src/pages/en/legal/index.mdx
@@ -1,0 +1,15 @@
+---
+permalink: /legal/
+title: Legal
+description: The nitty-gritty of the legal stuff for Quilt.
+layout: /src/layouts/Page.astro
+---
+
+This section contains the legal document for Quilt. If you have any questions,
+please contact us at [quiltmc.privacy@starchild.systems](mailto:quiltmc.privacy@starchild.systems)
+or in the `#discord-meta` channel on Discord.
+
+# Privacy Polices
+
+You can find the privacy polices on the left of the page, or underneath:
+* [ModMail Privacy Policy](/en/legal/modmail-privacy-policy/)

--- a/src/pages/en/legal/modmail-privacy-policy.mdx
+++ b/src/pages/en/legal/modmail-privacy-policy.mdx
@@ -1,0 +1,104 @@
+---
+permalink: /legal/modmail-privacy-policy/
+title: ModMail Privacy Policy
+description: The privacy police for the ModMail Discord bot and web interface.
+layout: /src/layouts/Page.astro
+---
+
+# Foreword
+
+Our ModMail+ instance is contracted to Starchild Systems.
+This document details what and why data is collected by Starchild Systems for QuiltMC,
+how it is used and how to use your rights related to your data.
+
+QuiltMC ("Us", "We", "Our") is the data controller for the data collected by Starchild Systems for QuiltMC.
+
+# Data Collected
+
+## Discord Bot
+
+We collect message content and attachments sent to the ModMail+ instance through Direct Message or by typing inside the thread channel.
+
+We also collect the following information about the sender:
+* Discord ID
+* Discord Username
+* Discord Discriminator
+* Discord Avatar URL
+
+We collect that data to preserve historical data and conduct moderation. The data is persisted across leaving the guild and is essential to the operation of the service.
+
+Attachments are stored inside a Content Delivery Network (CDN) to preserve data after the thread is closed.
+
+## Web Interface
+
+The web interface doesn't store any personal data.
+
+# Data Retention
+
+Data is retained indefinitely. We do not delete any data unless you request it.
+
+# Data Governance
+
+Database access is limited to the minimum of Starchild Systems employees required to operate the service. We do not share any data with third parties.
+We do not sell any data. Your data isn't shared with any contracted sub-processors other than Starchild Systems.
+
+Data is stored in a country part of the European Economic Area (EEA). Data is encrypted at rest and in transit.
+
+# Cookies
+
+Cookies are text files placed on your computer to collect standard Internet information.
+
+For further information, visit [allaboutcookies.org](https://allaboutcookies.org).
+
+## How do we use cookies?
+
+We use cookies inside the web interface to keep you signed in.
+
+## How to manage cookies?
+
+You can set your browser not to accept cookies, and the above website tells you how to remove cookies from your browser.
+However, in a few cases, some of our website features may not function as a result.
+
+# Access, rectification, erasure, restriction, portability, and objection
+
+Every user is entitled to the following:
+
+**The right to access** – You have the right to request Us for copies of your personal data.
+We may charge you a small fee for this service.
+
+**The right to rectification** – You have the right to request that We correct any information
+you believe is inaccurate. You also have the right to request Us to complete the information
+you believe is incomplete.
+
+**The right to erasure** – You have the right to request that We erase your personal data,
+under certain conditions.
+
+**The right to restrict processing** – You have the right to request that We restrict the
+processing of your personal data, under certain conditions.
+
+**The right to data portability** – You have the right to request that We transfer the data
+that we have collected to another organization, or directly to you, under certain conditions.
+
+**The right to object to processing** – You have the right to object to Our processing of
+your personal data, under certain conditions.
+
+If you would like to exercise thos rights, contact us at [quiltmc.privacy@starchild.systems](mailto:quiltmc.privacy@starchild.systems)
+or by sending a message to the ModMail+ Discord Bot.
+We may ask you to verify your identity before processing your request, using a service such as [Aperture](https://aperture.starchild.systems).
+We will respond to your request within 30 days as required by law.
+
+# Analytics
+
+We use [Cloudflare Web Analytics](https://www.cloudflare.com/en-gb/web-analytics/) to
+collect anonymous usage statistics of the web interface.
+Cloudflare does not collect or process personal data for Us.
+
+# Changes to the Privacy Policy
+
+We keep its privacy policy under regular review and places any updates on this web page.
+If we do this, we will post the changes on this page and update the "Edited" date at the top of this page.
+
+# Contact
+
+If you have any questions about this privacy policy, please contact us at
+[quiltmc.privacy@starchild.systems](mailto:quiltmc.privacy@starchild.systems) or by sending a message to the ModMail+ Discord Bot.

--- a/src/pages/en/legal/modmail-privacy-policy.mdx
+++ b/src/pages/en/legal/modmail-privacy-policy.mdx
@@ -7,6 +7,9 @@ layout: /src/layouts/Page.astro
 
 # Foreword
 
+The following document was created as required by the European Union General Data Protection Regulation (EU GDPR).
+You can find more information about that regulation on [gdpr.eu](https://gdpr.eu/).
+
 Our ModMail+ instance is contracted to Starchild Systems.
 This document details what and why data is collected by Starchild Systems for QuiltMC,
 how it is used and how to use your rights related to your data.
@@ -64,7 +67,7 @@ However, in a few cases, some of our website features may not function as a resu
 Every user is entitled to the following:
 
 **The right to access** – You have the right to request Us for copies of your personal data.
-We may charge you a small fee for this service.
+Starchild Systems may charge you a small fee on Our behalf for this service.
 
 **The right to rectification** – You have the right to request that We correct any information
 you believe is inaccurate. You also have the right to request Us to complete the information

--- a/src/pages/en/legal/modmail-privacy-policy.mdx
+++ b/src/pages/en/legal/modmail-privacy-policy.mdx
@@ -98,7 +98,7 @@ Cloudflare does not collect or process personal data for Us.
 
 # Changes to the Privacy Policy
 
-We keep its privacy policy under regular review and places any updates on this web page.
+We keep this privacy policy under regular review and places any updates on this web page.
 If we do this, we will post the changes on this page and update the "Edited" date at the top of this page.
 
 # Contact


### PR DESCRIPTION
This PR adds a privacy policy for the ModMail+ bot.

I've had to make use of a temporary email, quiltmc.privacy@starchild.systems, while we wait for @Haven-King to set up one under the quiltmc.org domain. That will have to be updated at a later date (due to the importance of this policy we shouldn't be waiting for this).

This policy is based on personal documents, the law itself, and [gdpr.eu](https://gdpr.eu/privacy-notice/).

Important notice: I am writing this document as a Data Controller from QuiltMC. Starchild Systems waives any responsibility for the usage of this policy.

[Rendered view](https://deploy-preview-86--ecstatic-booth-88897a.netlify.app/en/legal/modmail-privacy-policy/)