### PR TITLE
Cozy privacy policy

### DIFF
--- a/src/pages/en/legal/cozy-privacy-policy.mdx
+++ b/src/pages/en/legal/cozy-privacy-policy.mdx
@@ -43,7 +43,7 @@ We use this data to make sure you can't vote more than once.
 
 When you create a suggestion, we save your User ID, Username, Avatar Url, Message and whether it was proxied or not.
 
-We use the User ID and Message to keep track of suggestions, the rest is used to display the suggestion.
+We use this data to display and keep track of the suggestions. This data can be seen on the public analytics dashboard, without the User ID or Username.
 
 ## User Flags
 

--- a/src/pages/en/legal/cozy-privacy-policy.mdx
+++ b/src/pages/en/legal/cozy-privacy-policy.mdx
@@ -10,7 +10,7 @@ layout: /src/layouts/Page.astro
 The following document was created as required by the European Union General Data Protection Regulation (EU GDPR).
 You can find more information about that regulation on [gdpr.eu](https://gdpr.eu/).
 
-This document details what and why data is collected by QuiltMC,
+This document details what and why data is collected by QuiltMC through the Cozy Discord bots, except "Cozy (Stats)",
 how it is used and how to use your rights related to your data.
 
 QuiltMC ("Us", "We", "Our") is the data controller for the data collected through the Cozy Discord bots.

--- a/src/pages/en/legal/cozy-privacy-policy.mdx
+++ b/src/pages/en/legal/cozy-privacy-policy.mdx
@@ -41,7 +41,7 @@ We use this data to make sure you can't vote more than once.
 
 ### Creating a suggestion
 
-When you create a suggestion, we save your User ID, Username, Avatar Url, Message and whenever it was proxied or not.
+When you create a suggestion, we save your User ID, Username, Avatar Url, Message and whether it was proxied or not.
 
 We use the User ID and Message to keep track of suggestions, the rest is used to display the suggestion.
 
@@ -50,7 +50,7 @@ We use the User ID and Message to keep track of suggestions, the rest is used to
 We save three flags about you:
 - Has Used PluralKit: whether you have used PluralKit previously or not. We use that to log new usages of PluralKit for
 review by the moderators.
-- Auto Publish: whether your messsages sent in a news channel should be automatically published.
+- Auto Publish: whether your messages sent in a news channel should be automatically published.
 - Sync Nicknames: whether your nickname should be synced between Quilt guilds.
 
 # Data Retention

--- a/src/pages/en/legal/cozy-privacy-policy.mdx
+++ b/src/pages/en/legal/cozy-privacy-policy.mdx
@@ -1,0 +1,102 @@
+---
+permalink: /legal/cozy-privacy-policy/
+title: Cozy Privacy Policy
+description: The privacy police for the Cozy Discord bots.
+layout: /src/layouts/Page.astro
+---
+
+# Foreword
+
+The following document was created as required by the European Union General Data Protection Regulation (EU GDPR).
+You can find more information about that regulation on [gdpr.eu](https://gdpr.eu/).
+
+This document details what and why data is collected by QuiltMC,
+how it is used and how to use your rights related to your data.
+
+QuiltMC ("Us", "We", "Our") is the data controller for the data collected through the Cozy Discord bots.
+
+# Data Collected
+
+## Filter Events
+
+When you trigger an automatic filter, we record your User ID and the location of the message that triggered it.
+The message content isn't saved.
+
+We use this data to conduct analytics.
+
+## Threads
+
+If you are designated as the owner of a thread by creating it, or having the current owner transfer it to you,
+your User ID is saved alongside the thread ID.
+
+We use this data to allow you to manage the threads you own.
+
+## Suggestions
+
+### Voting
+
+When you vote positively or negatively, we save your User ID alongside the suggestion and your vote.
+
+We use this data to make sure you can't vote more than once.
+
+### Creating a suggestion
+
+When you create a suggestion, we save your User ID, Username, Avatar Url, Message and whenever it was proxied or not.
+
+We use the User ID and Message to keep track of suggestions, the rest is used to display the suggestion.
+
+## User Flags
+
+We save three flags about you:
+- Has Used PluralKit: whether you have used PluralKit previously or not. We use that to log new usages of PluralKit for
+review by the moderators.
+- Auto Publish: whether your messsages sent in a news channel should be automatically published.
+- Sync Nicknames: whether your nickname should be synced between Quilt guilds.
+
+# Data Retention
+
+Data is retained indefinitely. We do not delete any data unless you request it.
+
+# Data Governance
+
+Database access is limited to the minimum of QuiltMC benevolent workers required to operate the service. We do not share any data with third parties.
+We do not sell any data. Your data isn't shared with any contracted sub-processors.
+
+Data is stored in a country part of the European Economic Area (EEA). Data is encrypted at rest and in transit.
+
+# Access, rectification, erasure, restriction, portability, and objection
+
+Every user is entitled to the following:
+
+**The right to access** – You have the right to request Us for copies of your personal data.
+We may charge you a small fee for this service.
+
+**The right to rectification** – You have the right to request that We correct any information
+you believe is inaccurate. You also have the right to request Us to complete the information
+you believe is incomplete.
+
+**The right to erasure** – You have the right to request that We erase your personal data,
+under certain conditions.
+
+**The right to restrict processing** – You have the right to request that We restrict the
+processing of your personal data, under certain conditions.
+
+**The right to data portability** – You have the right to request that We transfer the data
+that we have collected to another organization, or directly to you, under certain conditions.
+
+**The right to object to processing** – You have the right to object to Our processing of
+your personal data, under certain conditions.
+
+If you would like to exercise those rights, contact us at [privacy@quiltmc.org](mailto:privacy@quiltmc.org).
+We may ask you to verify your identity before processing your request, using a service such as [Aperture](https://aperture.starchild.systems).
+We will respond to your request within 30 days as required by law.
+
+# Changes to the Privacy Policy
+
+We keep this privacy policy under regular review and places any updates on this web page.
+If we do this, we will post the changes on this page and update the "Edited" date at the top of this page.
+
+# Contact
+
+If you have any questions about this privacy policy, please contact us at
+[privacy@quiltmc.org](mailto:privacy@quiltmc.org).

--- a/src/pages/en/legal/index.mdx
+++ b/src/pages/en/legal/index.mdx
@@ -14,3 +14,4 @@ or in the `#discord-meta` channel on Discord.
 You can find the privacy polices on the left of the page, or underneath:
 * [Cozy Privacy Policy](/en/legal/cozy-privacy-policy/)
 * [ModMail Privacy Policy](/en/legal/modmail-privacy-policy/)
+* [Metricity Privacy Policy](/en/legal/metricity-privacy-policy/)

--- a/src/pages/en/legal/index.mdx
+++ b/src/pages/en/legal/index.mdx
@@ -12,4 +12,5 @@ or in the `#discord-meta` channel on Discord.
 # Privacy Polices
 
 You can find the privacy polices on the left of the page, or underneath:
+* [Cozy Privacy Policy](/en/legal/cozy-privacy-policy/)
 * [ModMail Privacy Policy](/en/legal/modmail-privacy-policy/)

--- a/src/pages/en/legal/metricity-privacy-policy.mdx
+++ b/src/pages/en/legal/metricity-privacy-policy.mdx
@@ -10,8 +10,8 @@ layout: /src/layouts/Page.astro
 The following document was created as required by the European Union General Data Protection Regulation (EU GDPR).
 You can find more information about that regulation on [gdpr.eu](https://gdpr.eu/).
 
-This document details what and why data is collected by QuiltMC,
-how it is used and how to use your rights related to your data.
+This document details what and why data is collected by QuiltMC through the "Cozy (Stats)" Discord bot
+running [Metricity](https://git.pydis.com/metricity), how it is used and how to use your rights related to your data.
 
 QuiltMC ("Us", "We", "Our") is the data controller for the data collected through the Cozy Discord bots.
 

--- a/src/pages/en/legal/metricity-privacy-policy.mdx
+++ b/src/pages/en/legal/metricity-privacy-policy.mdx
@@ -38,8 +38,8 @@ We collect the following information about users who are on one of our Guilds:
 * Creation date
 * Join date
 * Public Discord flags
-* Whenever the user is in the Guild
-* Whenever the user is considered as "pending" by Discord
+* Whether the user is in the Guild
+* Whether the user is considered as "pending" by Discord
 
 User data is kept after leaving the Guild, for erasure please see [Contact](#contact).
 

--- a/src/pages/en/legal/metricity-privacy-policy.mdx
+++ b/src/pages/en/legal/metricity-privacy-policy.mdx
@@ -1,7 +1,7 @@
 ---
-permalink: /legal/cozy-privacy-policy/
-title: Cozy Privacy Policy
-description: The privacy policy for the Cozy Discord bots.
+permalink: /legal/metricity-privacy-policy/
+title: Metricity Privacy Policy
+description: The privacy policy for the Metricity Discord bot.
 layout: /src/layouts/Page.astro
 ---
 
@@ -17,41 +17,39 @@ QuiltMC ("Us", "We", "Our") is the data controller for the data collected throug
 
 # Data Collected
 
-## Filter Events
+## Messages
 
-When you trigger an automatic filter, we record your User ID and the location of the message that triggered it.
-The message content isn't saved.
+We collect the following information about messages sent on the server:
+* Message ID
+* Author ID
+* Channel ID and Thread ID
+* Creation date
+* Whether the message is deleted or not
 
-We use this data to conduct analytics.
+The message content is **not** collected. Message data is kept after deletion from Discord, for erasure please see [Contact](#contact).
 
-## Threads
+## Users
 
-If you are designated as the owner of a thread by creating it, or having the current owner transfer it to you,
-your User ID is saved alongside the thread ID.
+We collect the following information about users who are on one of our Guilds:
+* User ID
+* Username
+* Avatar image hash
+* Guild avatar image hash
+* Creation date
+* Join date
+* Public Discord flags
+* Whenever the user is in the Guild
+* Whenever the user is considered as "pending" by Discord
 
-We use this data to allow you to manage the threads you own.
+User data is kept after leaving the Guild, for erasure please see [Contact](#contact).
 
-## Suggestions
+# Data usage
 
-### Voting
+The data is collected to provide statistics and identify bad actors.
+We do not make use of any automated decision making based on this data.
 
-When you vote positively or negatively, we save your User ID alongside the suggestion and your vote.
-
-We use this data to make sure you can't vote more than once.
-
-### Creating a suggestion
-
-When you create a suggestion, we save your User ID, Username, Avatar Url, Message and whenever it was proxied or not.
-
-We use the User ID and Message to keep track of suggestions, the rest is used to display the suggestion.
-
-## User Flags
-
-We save three flags about you:
-- Has Used PluralKit: whether you have used PluralKit previously or not. We use that to log new usages of PluralKit for
-review by the moderators.
-- Auto Publish: whether your messsages sent in a news channel should be automatically published.
-- Sync Nicknames: whether your nickname should be synced between Quilt guilds.
+No statistics containing private information will be provided publicly.
+We may use statistics containing private information internally.
 
 # Data Retention
 

--- a/src/pages/en/legal/modmail-privacy-policy.mdx
+++ b/src/pages/en/legal/modmail-privacy-policy.mdx
@@ -1,7 +1,7 @@
 ---
 permalink: /legal/modmail-privacy-policy/
 title: ModMail Privacy Policy
-description: The privacy police for the ModMail Discord bot and web interface.
+description: The privacy policy for the ModMail Discord bot and web interface.
 layout: /src/layouts/Page.astro
 ---
 


### PR DESCRIPTION
This PR adds a privacy policy for the Cozy bots, based on #86.

[Cozy bots](https://deploy-preview-87--ecstatic-booth-88897a.netlify.app/en/legal/cozy-privacy-policy/)
[Metricity](https://deploy-preview-87--ecstatic-booth-88897a.netlify.app/en/legal/metricity-privacy-policy/)

I also fixed a typo in the ModMail privacy policy meta tags.