### PR TITLE
Switch CI to Github Actions

### DIFF
--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -29,7 +29,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: staging-quiltmc-org
           directory: dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           branch: push-snapshot
 
       - name: Add a comment on the commit

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -37,6 +37,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          commit: ${{ github.sha }}
-          body: |
-            See preview on Cloudflare Pages: ${{ steps.publish.outputs.url }}
+          sha: ${{ github.sha }}
+          body: "See preview on Cloudflare Pages: ${{ steps.publish.outputs.url }}"

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -1,4 +1,5 @@
 on: [push]
+name: Commit preview
 
 jobs:
   deploy:

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -1,0 +1,42 @@
+on: [push]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    name: Generate commit preview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+			- name: Install dependencies
+				run: pnpm install
+
+			- name: Build the project
+				run: pnpm build
+
+      - name: Publish to Pages
+        uses: cloudflare/pages-action@1
+				id: publish
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: staging-quiltmc-org
+          directory: dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+					branch: push-snapshot
+
+			- name: Add a comment on the commit
+				uses: peter-evans/commit-comment@v1
+				with:
+					token: ${{ secrets.GITHUB_TOKEN }}
+					repository: ${{ github.repository }}
+					commit: ${{ github.sha }}
+					body: |
+						See preview on Cloudflare Pages: ${{ steps.publish.outputs.url }}

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Add a comment on the commit
         uses: peter-evans/commit-comment@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.COZY_PAT }}
           repository: ${{ github.repository }}
           sha: ${{ github.sha }}
           body: "See preview on Cloudflare Pages: ${{ steps.publish.outputs.url }}"

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -29,7 +29,6 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: staging-quiltmc-org
           directory: dist
-          branch: push-snapshot
 
       - name: Add a comment on the commit
         uses: peter-evans/commit-comment@v1

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -15,28 +15,28 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm
 
-			- name: Install dependencies
-				run: pnpm install
+      - name: Install dependencies
+        run: pnpm install
 
-			- name: Build the project
-				run: pnpm build
+      - name: Build the project
+        run: pnpm build
 
       - name: Publish to Pages
         uses: cloudflare/pages-action@1
-				id: publish
+        id: publish
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: staging-quiltmc-org
           directory: dist
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-					branch: push-snapshot
+          branch: push-snapshot
 
-			- name: Add a comment on the commit
-				uses: peter-evans/commit-comment@v1
-				with:
-					token: ${{ secrets.GITHUB_TOKEN }}
-					repository: ${{ github.repository }}
-					commit: ${{ github.sha }}
-					body: |
-						See preview on Cloudflare Pages: ${{ steps.publish.outputs.url }}
+      - name: Add a comment on the commit
+        uses: peter-evans/commit-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          commit: ${{ github.sha }}
+          body: |
+            See preview on Cloudflare Pages: ${{ steps.publish.outputs.url }}

--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -10,7 +10,10 @@ jobs:
     name: Generate commit preview
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: akarys42/checkout-with-filter@main
+        with:
+          filter: 'blob:none'
+          fetch-depth: 0
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.github/workflows/pr-preview-footer.yaml
+++ b/.github/workflows/pr-preview-footer.yaml
@@ -1,6 +1,7 @@
 on:
   pull_request_target:
     types: [opened]
+name: Add footer to PR
 
 jobs:
   deploy:

--- a/.github/workflows/pr-preview-footer.yaml
+++ b/.github/workflows/pr-preview-footer.yaml
@@ -1,0 +1,20 @@
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    name: Add preview footer to PR
+    steps:
+    - name: Add preview footer to PR
+      uses: devindford/Append_PR_Comment@v1.1.2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        body-template: |
+          ---
+          See preview on Cloudflare Pages: https://preview-${{ github.event.number }}.staging-quiltmc-org.pages.dev
+        body-update-action: 'suffix'

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,4 +1,5 @@
 on: [pull_request]
+name: PR preview
 
 jobs:
   deploy:

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,33 @@
+on: [pull_request]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+
+    name: Generate PR preview
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build the project
+        run: pnpm build
+
+      - name: Publish to Pages
+        uses: cloudflare/pages-action@1
+        id: publish
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: staging-quiltmc-org
+          directory: dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: preview-${{ github.event.number }}

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -10,7 +10,10 @@ jobs:
     name: Generate PR preview
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: akarys42/checkout-with-filter@main
+        with:
+          filter: 'blob:none'
+          fetch-depth: 0
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -29,5 +29,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: staging-quiltmc-org
           directory: dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           branch: preview-${{ github.event.number }}


### PR DESCRIPTION
This switches our CI from pages-ci to Github Actions. It will allow us to have much more control over the build environment and create previews from PRs. 

This changes slightly how previews are displayed. A comment will be added to every pushed commit with a link to a preview, and each PR will automatically get a preview URL appended to the end of its body.