### PR TITLE
Ask ChatGPT to not visit the teams page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: ChatGPT-User
+Disallow: /*/about/teams/


### PR DESCRIPTION
[According to OpenAI's documentation](https://platform.openai.com/docs/plugins/bot), ChatGPT will honor `robots.txt` directive. This kindly asks them to not look at the teams page, to protect personal information there.

---
See preview on Cloudflare Pages: https://preview-124.quiltmc-org.pages.dev