### PR TITLE
fix channel name in troubleshooting page

### DIFF
--- a/src/pages/en/usage/troubleshooting.mdx
+++ b/src/pages/en/usage/troubleshooting.mdx
@@ -60,7 +60,7 @@ to figure out if this is the case, and you can attempt to do so by following the
    half and test each half until you've managed to isolate the problematic mod.
 
 If this doesn't help, or you have trouble reading the logs on your own, please feel free to drop into the
-`#quilt-support` channel on [The Quilt Community Discord server](https://discord.quiltmc.org), and we'll try to
+`#quilt-basic-support` channel on [The Quilt Community Discord server](https://discord.quiltmc.org), and we'll try to
 help you out. **Please remember to provide your `latest.log` and any other relevant issue when requesting support!**
 
 </Message>


### PR DESCRIPTION
it's `quilt-basic-support` now

---
See preview on Cloudflare Pages: https://preview-137.quiltmc-org.pages.dev