### PR TITLE
Remove myself from teams

### DIFF
--- a/src/data/TeamData.mjs
+++ b/src/data/TeamData.mjs
@@ -414,17 +414,6 @@ export default {
 		avatar: "/assets/img/team/Redblueflame.png",
 		links: [{ icon: "fas fa-link", url: "https://redblueflame.com/" }],
 	},
-	SilverAndro: {
-		name: "Silver",
-		discord: "Silver <3",
-		github: "SilverAndro",
-		avatar: "https://avatars.githubusercontent.com/u/52360088",
-		description: "Trans programmer working with Kotlin. Plays too much warframe.",
-		links: [
-			{ icon: "fab fa-twitter", url: "https://twitter.com/SilverAndro" },
-			{ icon: "fab fa-tumblr", url: "https://silverandro.tumblr.com"}
-		],
-	},
 	Southpaw: {
 		name: "Southpaw1496",
 		discord: "Southpaw1496",


### PR DESCRIPTION
Still somehow listed as a mod even though i left that position over a month ago

Backing data (https://team-info.quiltmc.org/) seems correct so assuming the cache doesnt fuck this up this is mostly just a rebuild pr as well as removing me from the list of people

---
See preview on Cloudflare Pages: https://preview-138.quiltmc-org.pages.dev