### PR TITLE
Update incompatible-mods.json

### DIFF
--- a/public/incompatible-mods.json
+++ b/public/incompatible-mods.json
@@ -49,13 +49,6 @@
   },
 
   {
-    "ids": ["viafabricplus"],
-    "name": "ViaFabricPlus",
-    "type": "GAME",
-    "note": "Only occurs on linux"
-  },
-
-  {
     "ids": ["vulkanmod"],
     "name": "VulkanMod",
     "type": "GAME"


### PR DESCRIPTION
ViaFabric+ no longer causes issues (Tested on Quilt 0.8.2, OpenJ9 21)

---
See preview on Cloudflare Pages: https://preview-154.quiltmc-org.pages.dev