### PR TITLE
Change actions back

### DIFF
--- a/.github/workflows/commit-preview.yaml
+++ b/.github/workflows/commit-preview.yaml
@@ -11,7 +11,10 @@ jobs:
     name: Generate commit preview
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: akarys42/checkout-with-filter@main
+        with:
+          filter: 'blob:none'
+          fetch-depth: 0
 
       - name: Enable Corepack shims
         run: corepack enable

--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -11,7 +11,10 @@ jobs:
     name: Publish website
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: akarys42/checkout-with-filter@main
+        with:
+          filter: 'blob:none'
+          fetch-depth: 0
 
       - name: Enable Corepack shims
         run: corepack enable

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -10,7 +10,10 @@ jobs:
     name: Generate PR preview
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: akarys42/checkout-with-filter@main
+        with:
+          filter: 'blob:none'
+          fetch-depth: 0
 
       - name: Enable Corepack shims
         run: corepack enable


### PR DESCRIPTION
Recently I changed our CI pipeline to use GitHub's default `actions/checkout` instead of a custom one. It turns out the custom one *was* important.

---
See preview on Cloudflare Pages: https://preview-164.quiltmc-org.pages.dev