### PR TITLE
Remove myself from the QuiltMC website

### DIFF
--- a/src/data/TeamData.mjs
+++ b/src/data/TeamData.mjs
@@ -418,13 +418,6 @@ export default {
 		description:
 			"Minecraft Modder who enjoys the comfortable feeling of crocs on their feet",
 	},
-	Zxhir: {
-		name: "Zxhir",
-		discord: ".zxhir",
-		github: "Imzxhir",
-		description: "I am a potato who does random things and tries to improve on my own skills one at a time. I also like to write",
-		avatar: "https://avatars.githubusercontent.com/u/98621617?v=4",
-	},
 	Zoe: {
 		name: "Zoe",
 		discord: "antikyth",


### PR DESCRIPTION
Description: This PR removes myelf from the QuiltMC wesbite since I have left the outreach team.

One thing I noticed was that when I removed myself from the 'TeamData.mjs', it replaced me with 'Member not found' which I am not sure on how to fix. Here is a screenshot showcasing this:

![image](https://github.com/QuiltMC/quiltmc.org/assets/98621617/ee9ff2af-a5b4-4faf-9155-99a242f1dbc0)


---
See preview on Cloudflare Pages: https://preview-172.quiltmc-org.pages.dev