### PR TITLE
Fix warning message to be less "scary"

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"i18next-fluent": "^2.0.0",
 		"i18next-fs-fluent-backend": "github:pluiedev/i18next-fs-fluent-backend",
 		"node-fetch": "^3.3.2",
-		"quilt-bulma": "0.0.23",
+		"quilt-bulma": "0.0.24",
 		"rehype-autolink-headings": "^6.1.1",
 		"rollup": "^3.29.4",
 		"sass": "^1.69.4",

--- a/src/components/parts/install/WipWarning.astro
+++ b/src/components/parts/install/WipWarning.astro
@@ -4,7 +4,7 @@ import HomeMessage from "@parts/home/HomeMessage.astro";
 import { Trans } from "astro-i18next/components";
 ---
 
-<HomeMessage style="danger" iconType="danger" icon="warning" tKey="wip">
+<HomeMessage style="warning" tKey="wip">
 	<Trans i18nKey="install:wip-warning">
 		<p>
 			<strong>Quilt is in beta.</strong> Here be dragons - there may be issues, but

--- a/src/components/parts/install/WipWarning.astro
+++ b/src/components/parts/install/WipWarning.astro
@@ -4,7 +4,7 @@ import HomeMessage from "@parts/home/HomeMessage.astro";
 import { Trans } from "astro-i18next/components";
 ---
 
-<HomeMessage style="warning" tKey="wip">
+<HomeMessage style="warning" iconType="danger" icon="warning" tKey="wip">
 	<Trans i18nKey="install:wip-warning">
 		<p>
 			<strong>Quilt is in beta.</strong> Here be dragons - there may be issues, but

--- a/src/layouts/Home.astro
+++ b/src/layouts/Home.astro
@@ -19,7 +19,7 @@ import SponsorRow from "@parts/sponsors/SponsorRow.astro";
 			</div>
 
 			<div class="column is-4">
-				<HomeMessage style="danger" iconType="danger" icon="warning" tKey="wip">
+				<HomeMessage style="success" tKey="wip">
 					<slot name="wip" />
 				</HomeMessage>
 			</div>

--- a/src/layouts/Home.astro
+++ b/src/layouts/Home.astro
@@ -19,7 +19,7 @@ import SponsorRow from "@parts/sponsors/SponsorRow.astro";
 			</div>
 
 			<div class="column is-4">
-				<HomeMessage style="success" tKey="wip">
+				<HomeMessage style="warning" tKey="wip">
 					<slot name="wip" />
 				</HomeMessage>
 			</div>

--- a/src/layouts/Home.astro
+++ b/src/layouts/Home.astro
@@ -19,7 +19,7 @@ import SponsorRow from "@parts/sponsors/SponsorRow.astro";
 			</div>
 
 			<div class="column is-4">
-				<HomeMessage style="warning" tKey="wip">
+				<HomeMessage style="warning" iconType="danger" icon="warning" tKey="wip">
 					<slot name="wip" />
 				</HomeMessage>
 			</div>

--- a/src/layouts/Home.astro
+++ b/src/layouts/Home.astro
@@ -19,7 +19,7 @@ import SponsorRow from "@parts/sponsors/SponsorRow.astro";
 			</div>
 
 			<div class="column is-4">
-				<HomeMessage style="warning" iconType="danger" icon="warning" tKey="wip">
+				<HomeMessage style="warning" iconType="warning" icon="warning" tKey="wip">
 					<slot name="wip" />
 				</HomeMessage>
 			</div>


### PR DESCRIPTION
All I did was make it use the `success` styling found in the "Powerful" message box on the main site. I also was unable to test this locally because of this: https://mclo.gs/wr6vtB4



---
See preview on Cloudflare Pages: https://preview-176.quiltmc-org.pages.dev