### PR TITLE
Fix mod generator script (closes #212)

### DIFF
--- a/src/layouts/Generator.astro
+++ b/src/layouts/Generator.astro
@@ -350,16 +350,18 @@ const props = Astro.props;
             modZip.file("README.md", readme);
 
             // libs.versions.toml
-            const topOfFile = `[versions]
-# The latest versions are available at https://quiltmc.org/en/usage/latest-versions
+            const topOfFile = `# The latest versions are available at https://quiltmc.org/en/usage/latest-versions
+[versions]
 minecraft = "${version}"
-loom = "${components.loom}"
-
 quilt_mappings = "${components.quilt_mappings}"
+
+quilt_loom = "${components.loom}"
 quilt_loader = "${components.quilt_loader}"
 
-quilted_fabric_api = "${components.quilted_fabric_api}"`
-            const bottomOfFile = (await origZip.file("gradle/libs.versions.toml").async("string")).replace(/\[versions\](.|\n)*?/, "");
+quilted_fabric_api = "${components.quilted_fabric_api}"
+
+[libraries]`;
+            const bottomOfFile = (await origZip.file("gradle/libs.versions.toml").async("string")).replace(/\[versions\](.|\n)*?\[libraries\]/, "");
 
             const libsVersionToml = topOfFile + "\n\n" + bottomOfFile;
             modZip.file("gradle/libs.versions.toml", libsVersionToml);

--- a/src/layouts/Generator.astro
+++ b/src/layouts/Generator.astro
@@ -358,10 +358,9 @@ quilt_mappings = "${components.quilt_mappings}"
 quilt_loom = "${components.loom}"
 quilt_loader = "${components.quilt_loader}"
 
-quilted_fabric_api = "${components.quilted_fabric_api}"
-
-[libraries]`;
-            const bottomOfFile = (await origZip.file("gradle/libs.versions.toml").async("string")).replace(/\[versions\](.|\n)*?\[libraries\]/, "");
+quilted_fabric_api = "${components.quilted_fabric_api}"`;
+			const origFile = await origZip.file("gradle/libs.versions.toml").async("string");
+            const bottomOfFile = origFile.substring(origFile.indexOf("[libraries]"));
 
             const libsVersionToml = topOfFile + "\n\n" + bottomOfFile;
             modZip.file("gradle/libs.versions.toml", libsVersionToml);

--- a/src/layouts/Generator.astro
+++ b/src/layouts/Generator.astro
@@ -359,9 +359,9 @@ quilt_mappings = "${components.quilt_mappings}"
 quilt_loader = "${components.quilt_loader}"
 
 quilted_fabric_api = "${components.quilted_fabric_api}"`
-            const bottomOfFile = (await origZip.file("gradle/libs.versions.toml").async("string")).replace(/\[versions\](.|\n)*?\[/, "");
+            const bottomOfFile = (await origZip.file("gradle/libs.versions.toml").async("string")).replace(/\[versions\](.|\n)*?/, "");
 
-            const libsVersionToml = topOfFile + "\n\n[" + bottomOfFile;
+            const libsVersionToml = topOfFile + "\n\n" + bottomOfFile;
             modZip.file("gradle/libs.versions.toml", libsVersionToml);
 
             // LICENSE.md

--- a/src/layouts/Generator.astro
+++ b/src/layouts/Generator.astro
@@ -89,8 +89,8 @@ const props = Astro.props;
         <label class="label">Java namespace:*</label>
         <div class="tabs is-toggle mb-4">
             <ul class="mt-0">
-                <li id="tab-domain" class="is-active"><a>I have my own domain</a></li>
-                <li id="tab-github"><a>I am a GitHub user</a></li>
+				<li id="tab-github" class="is-active"><a>I am a GitHub user</a></li>
+                <li id="tab-domain"><a>I have my own domain</a></li>
                 <li id="tab-provide"><a>I have neither of those</a></li>
             </ul>
         </div>


### PR DESCRIPTION
- Fix generator script
- re-order fields to match the latest versions list + template mod
- make github the default option for package naming

---
See preview on Cloudflare Pages: https://preview-213.quiltmc-org.pages.dev