### PR TITLE
Fix scripts running when they should not

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@types/luxon": "^3.3.3",
 				"@types/prismjs": "^1.26.3",
 				"@types/semver-compare": "^1.0.3",
+				"@types/semver-sort": "^0.0.5",
 				"@types/swagger-ui": "^3.52.4",
 				"astro": "1.6.14",
 				"astro-i18next": "1.0.0-beta.12",
@@ -2685,6 +2686,12 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@types/semver-compare/-/semver-compare-1.0.3.tgz",
 			"integrity": "sha512-mVZkB2QjXmZhh+MrtwMlJ8BqUnmbiSkpd88uOWskfwB8yitBT0tBRAKt+41VRgZD9zr9Sc+Xs02qGgvzd1Rq/Q==",
+			"dev": true
+		},
+		"node_modules/@types/semver-sort": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@types/semver-sort/-/semver-sort-0.0.5.tgz",
+			"integrity": "sha512-cIQG7kjdzHcsRrYYkP8N65BogntqItjMjG8uSgPEl1ej4dKj9QC8snCFJb3HHF/Cwqe0s0IflJjUU5wb1yrLDQ==",
 			"dev": true
 		},
 		"node_modules/@types/swagger-ui": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"@types/luxon": "^3.3.3",
 		"@types/prismjs": "^1.26.3",
 		"@types/semver-compare": "^1.0.3",
+		"@types/semver-sort": "^0.0.5",
 		"@types/swagger-ui": "^3.52.4",
 		"astro": "1.6.14",
 		"astro-i18next": "1.0.0-beta.12",

--- a/src/components/parts/install/InstallerVersion.astro
+++ b/src/components/parts/install/InstallerVersion.astro
@@ -3,26 +3,31 @@ import { t } from "i18next";
 ---
 
 <div class="field-label is-normal mt-1">
-	<span class="title is-6" id="installer-version"
-		>{t("install:installer-version-placeholder")}
-	</span>
-
-	<script>
-		import semverSort from "semver-sort";
-
-		const VERSION_REGEX = /<version>(.+?)<\/version>/g;
-
-		const INSTALLER_URL_BASE =
-			"https://maven.quiltmc.org/repository/release/org/quiltmc/quilt-installer/";
-		const MAVEN_METADATA_URL = INSTALLER_URL_BASE + "maven-metadata.xml";
-
-		const metadataRequest = await fetch(MAVEN_METADATA_URL, { headers: { "User-Agent": "QuiltMC Website API" } })
-		const metadata = await metadataRequest.text()
-		const allVersion = Array.from(metadata.matchAll(VERSION_REGEX)).map(match => match[1])
-		const latest = semverSort.desc(allVersion)[0]
-
-		if (document.getElementById("installer-version")) {
-			document.getElementById("installer-version").textContent = latest;
-		}
-	</script>
+	<installer-version class="title is-6">
+		{t("install:installer-version-placeholder")}
+	</installer-version>
 </div>
+
+<script>
+	import semverSort from "semver-sort";
+
+	const VERSION_REGEX = /<version>(.+?)<\/version>/g;
+	const INSTALLER_URL_BASE =
+		"https://maven.quiltmc.org/repository/release/org/quiltmc/quilt-installer/";
+	const MAVEN_METADATA_URL = INSTALLER_URL_BASE + "maven-metadata.xml";
+
+	class InstallerVersion extends HTMLElement {
+		constructor() {
+			super();
+		}
+
+		async connectedCallback() {
+			const metadataRequest = await fetch(MAVEN_METADATA_URL, { headers: { "User-Agent": "QuiltMC Website API" } });
+			const metadata = await metadataRequest.text();
+			const allVersion = Array.from(metadata.matchAll(VERSION_REGEX)).map(match => match[1]);
+			this.textContent = semverSort.desc(allVersion)[0]; // latest
+		}
+	}
+
+	customElements.define('installer-version', InstallerVersion);
+</script>

--- a/src/pages/api.astro
+++ b/src/pages/api.astro
@@ -5,15 +5,16 @@ import swaggerDarkCss from "../styles/swagger-dark.css?raw";
 ---
 
 <script>
-    import SwaggerUI from 'swagger-ui';
-
-    window.addEventListener("load", () => {
-        window.ui = SwaggerUI({
-            url: '/api/openapi.yaml',
-            dom_id: '#swagger-ui',
-            deepLinking: true,
-        });
-    });
+	const swaggerUiNode = document.getElementById('swagger-ui');
+	if (swaggerUiNode) {
+		import('swagger-ui').then(({ default: renderSwagger }) => {
+			window.ui = renderSwagger({
+				url: '/api/openapi.yaml',
+				domNode: swaggerUiNode,
+				deepLinking: true,
+			});
+		});
+	}
 </script>
 <style is:inline>
     pre.version {


### PR DESCRIPTION
For the Swagger UI I used a dynamic import so the script gets split into its own chunk, and only gets loaded on the relevant page.
For the installer version, the imported module is really small so a dynamic import was not needed. As for the "condition", I noticed the Astro doc was suggesting [web components to implement custom behaviour](https://docs.astro.build/en/guides/client-side-scripts/#web-components-with-custom-elements), and I figured it would do a decent job at structuring the code, so I used this instead of a basic `getElementById`.

fixes #215
fixes #216 



---
See preview on Cloudflare Pages: https://preview-217.quiltmc-org.pages.dev