### PR TITLE
Use builtin date instead of querying meta

### DIFF
--- a/src/layouts/PatchNotes.astro
+++ b/src/layouts/PatchNotes.astro
@@ -144,38 +144,23 @@ import Base from "./Base.astro";
 
 				// Create nav-links
 
-				// Query meta, because meta contains the versions in their proper order
-				fetch("https://meta.quiltmc.org/v3/versions/game")
-					.then((response) => response.json())
-					.then((meta) => {
-						const version2index = {};
-						var i = 0;
-						meta.forEach((entry) => {
-							version2index[entry.version] = i++;
-						});
+				data.entries.sort((a,b) => Date.parse(b.date) - Date.parse(a.date));
+				data.entries.forEach((entry) => {
+					const listItem = document.createElement("li");
+					const newRef = document.createElement("a");
 
-						data.entries.sort((a,b) => version2index[a.version] - version2index[b.version]);
-					})
-					.catch(e => console.warn("Failed to sort versions", e))
-					.finally(() => {
-						// Insert the (hopefully sorted) entries into the dom
-						data.entries.forEach((entry) => {
-							const listItem = document.createElement("li");
-							const newRef = document.createElement("a");
+					newRef.classList.add("version-item");
+					newRef.dataset["action"] = "click->sidebar#toggle";
+					newRef.id = entry.version;
+					newRef.innerText = entry.version;
+					newRef.setAttribute(
+						"href",
+						window.location.pathname + "#" + entry.version
+					);
 
-							newRef.classList.add("version-item");
-							newRef.dataset["action"] = "click->sidebar#toggle";
-							newRef.id = entry.version;
-							newRef.innerText = entry.version;
-							newRef.setAttribute(
-								"href",
-								window.location.pathname + "#" + entry.version
-							);
-
-							listItem.appendChild(newRef);
-							document.getElementById("sidebar").appendChild(listItem);
-						});
-					});
+					listItem.appendChild(newRef);
+					document.getElementById("sidebar").appendChild(listItem);
+				});
 
 				// Rerender the patch note when the url changes
 				window.onhashchange = render;


### PR DESCRIPTION
Mojang has added a date field to the patch notes a while back, which should be more stable to use. There was a [conversation](<https://discord.com/channels/817576132726620200/833939559636271105/1228262594008317952>) about this a while back, meta takes longer to update causing new version to be sorted incorrectly. This also removes a network request

---
See preview on Cloudflare Pages: https://preview-218.quiltmc-org.pages.dev/