### PR TITLE
Restore/improve patchnote behaviour

### DIFF
--- a/src/layouts/PatchNotes.astro
+++ b/src/layouts/PatchNotes.astro
@@ -94,6 +94,15 @@ import Base from "./Base.astro";
 			}
 		}
 
+		@media screen and (min-width: 769px), print {
+			#body {
+				// Reserves extra height equal to the version selection sidebar's height.
+				// This ensures that the scrollbar can fit fully on-screen. Even if the
+				// page has been scrolled such that the title of the body is exactly on top.
+				min-height: calc(100vh - 2rem);
+			}
+		}
+
 		.reset-overflow {
 			overflow-x: unset !important;
 		}

--- a/src/layouts/PatchNotes.astro
+++ b/src/layouts/PatchNotes.astro
@@ -11,7 +11,8 @@ import Base from "./Base.astro";
 				<div class="columns reset-overflow">
 					<div class="column is-narrow">
 						<div class="is-hidden-tablet">
-							<button class="button is-primary" id="sidebar-button">
+							<button class="button is-primary" id="sidebar-button"
+									aria-controls="sidebar-box" aria-haspopup="menu">
 								<span class="icon"><i class="fas fa-ellipsis-h"></i></span>
 								<span>{t("sidebar-versions")}</span>
 							</button>
@@ -123,6 +124,7 @@ import Base from "./Base.astro";
 		var mobileSidebarEnabled = false;
 		function updateSidebar(enabled) {
 			mobileSidebarEnabled = enabled;
+			document.getElementById("sidebar-button").ariaExpanded = enabled;
 			if (mobileSidebarEnabled) {
 				// Sidebar is enabled, so we need to un-hide it
 				document.getElementById("sidebar-box").classList.remove("is-hidden-mobile");

--- a/src/layouts/PatchNotes.astro
+++ b/src/layouts/PatchNotes.astro
@@ -5,10 +5,10 @@ import Base from "./Base.astro";
 ---
 
 <Base content={Astro.props.content}>
-	<main class="columns is-centered">
+	<main class="columns is-centered reset-overflow">
 		<div class="column is-10">
 			<section class="section">
-				<div class="columns">
+				<div class="columns reset-overflow">
 					<div class="column is-narrow">
 						<div class="is-hidden-tablet">
 							<button class="button is-primary" id="sidebar-button">
@@ -92,6 +92,10 @@ import Base from "./Base.astro";
 			#missing-versions-warning {
 				display: none !important;
 			}
+		}
+
+		.reset-overflow {
+			overflow-x: unset !important;
 		}
 	</style>
 

--- a/src/layouts/PatchNotes.astro
+++ b/src/layouts/PatchNotes.astro
@@ -159,7 +159,7 @@ import Base from "./Base.astro";
 							elem.classList.remove("is-active");
 						}
 
-						document.getElementById(entry.version).classList.add("is-active");
+						document.getElementById("button-"+entry.version).classList.add("is-active");
 						// document.getElementsByClassName("menu")[0].scrollIntoView()
 					} else {
 						// If no version is selected currently, open the sidebar
@@ -189,7 +189,7 @@ import Base from "./Base.astro";
 							const newRef = document.createElement("a");
 
 							newRef.classList.add("version-item");
-							newRef.id = entry.version;
+							newRef.id = "button-"+entry.version;
 							newRef.innerText = entry.version;
 							newRef.setAttribute(
 								"href",

--- a/src/layouts/PatchNotes.astro
+++ b/src/layouts/PatchNotes.astro
@@ -11,7 +11,7 @@ import Base from "./Base.astro";
 				<div class="columns">
 					<div class="column is-narrow">
 						<div class="is-hidden-tablet">
-							<button class="button is-primary">
+							<button class="button is-primary" id="sidebar-button">
 								<span class="icon"><i class="fas fa-ellipsis-h"></i></span>
 								<span>{t("sidebar-versions")}</span>
 							</button>
@@ -20,7 +20,7 @@ import Base from "./Base.astro";
 							<br />
 						</div>
 
-						<div class="box is-hidden-mobile is-sticky">
+						<div class="box is-hidden-mobile is-sticky" id="sidebar-box">
 							<aside class="menu">
 								<p class="menu-label">{t("sidebar-versions")}</p>
 
@@ -99,6 +99,22 @@ import Base from "./Base.astro";
 		const baseUrl = "https://launchercontent.mojang.com";
 		const v2Url = baseUrl+"/v2";
 
+		// This only applies to mobile. On desktop the sidebar is always enabled.
+		var mobileSidebarEnabled = false;
+		function updateSidebar(enabled) {
+			mobileSidebarEnabled = enabled;
+			if (mobileSidebarEnabled) {
+				// Sidebar is enabled, so we need to un-hide it
+				document.getElementById("sidebar-box").classList.remove("is-hidden-mobile");
+			} else {
+				// Sidebar is disabled, so we need to hide it
+				document.getElementById("sidebar-box").classList.add("is-hidden-mobile");
+			}
+		}
+
+		// Toggle sidebar when button is pressed
+		document.getElementById("sidebar-button").onclick = () => updateSidebar(!mobileSidebarEnabled);
+
 		// Fetch launcher metadata
 		fetch(v2Url + "/javaPatchNotes.json")
 			.then((response) => response.json())
@@ -110,6 +126,8 @@ import Base from "./Base.astro";
 					var entry = data.entries.find((e) => e.version === version);
 
 					if (entry) {
+						// Once a version is selected, we close the sidebar
+						updateSidebar(false);
 						document.getElementById("title").scrollIntoView();
 
 						// Replace title, body and image url with the selected version
@@ -139,6 +157,9 @@ import Base from "./Base.astro";
 
 						document.getElementById(entry.version).classList.add("is-active");
 						// document.getElementsByClassName("menu")[0].scrollIntoView()
+					} else {
+						// If no version is selected currently, open the sidebar
+						updateSidebar(true);
 					}
 				};
 
@@ -164,7 +185,6 @@ import Base from "./Base.astro";
 							const newRef = document.createElement("a");
 
 							newRef.classList.add("version-item");
-							newRef.dataset["action"] = "click->sidebar#toggle";
 							newRef.id = entry.version;
 							newRef.innerText = entry.version;
 							newRef.setAttribute(

--- a/src/layouts/PatchNotes.astro
+++ b/src/layouts/PatchNotes.astro
@@ -68,6 +68,8 @@ import Base from "./Base.astro";
 							</div>
 						</div>
 
+						<div id="before-content"></div>
+
 						<h1 id="title" class="title">
 							<slot name="patchnotes" />
 						</h1>
@@ -101,6 +103,11 @@ import Base from "./Base.astro";
 				// page has been scrolled such that the title of the body is exactly on top.
 				min-height: calc(100vh - 2rem);
 			}
+		}
+
+		#before-content {
+			// Translation equal to the padding which is above the title of the changelog.
+			transform: translateY(-1.5rem);
 		}
 
 		.reset-overflow {
@@ -141,7 +148,9 @@ import Base from "./Base.astro";
 					if (entry) {
 						// Once a version is selected, we close the sidebar
 						updateSidebar(false);
-						document.getElementById("title").scrollIntoView();
+
+						// Scroll to the top of the changelog
+						document.getElementById("before-content").scrollIntoView();
 
 						// Replace title, body and image url with the selected version
 						document.getElementById("title").innerText = entry.title;


### PR DESCRIPTION
Thought it'd be easier to combine these instead of creating separate pr's ^^

This pr fixes the version selector on mobile. It now has the same behaviour as before it broke (which you can view [here](<http://web.archive.org/web/20220316231936/https://quiltmc.org/mc-patchnotes>) on the wayback machine). With one exception, the sidebar is now automatically opened if the url fragment is empty. Aria-roles have also been added to this button.

The sidebar is also intended to be sticky on desktop, but that broke at some point. By unsetting the `overflow-x` property this is now restored. This seems to have no side-effects on how the overflow works. (Don't think it would've mattered anyway unless you had an absurdly small screen).

When pressing versions, the scrolling was also very wonky. This was because all of the buttons had ids equal to their versions. When the url fragment was set to that version, the browser tried to scroll to the button. I also made the it keep the padding above the title when it scrolled to the top of the page. (It now scrolls slightly above the top of the title, instead of making the title sit right on the top of your screen). Additionally, I made sure the sidebar has enough room when the changelog is smaller than the height of your screen. This ensures that the sidebar can keep the same position on both small and large changelogs. 

Combined, this means browsing through changelogs is now way smoother.

---
See preview on Cloudflare Pages: https://preview-220.quiltmc-org.pages.dev