### PR TITLE
Add Feather Client to the list of incompatible mods

### DIFF
--- a/public/api/v1/incompatible-mods.json
+++ b/public/api/v1/incompatible-mods.json
@@ -131,5 +131,14 @@
     "tracking": "https://github.com/Ladysnake/Requiem/issues/670",
     "note": "Creating an obelisk crashes the game when using some versions of QSL. Use [QSL 4.0.0-beta.30](https://modrinth.com/mod/qsl/version/4.0.0-beta.30+0.76.0-1.19.2) as a workaround.",
     "icon": "https://cdn.modrinth.com/data/bYmqMxlQ/41b48c13bc4acd691dccc93b09c97995f0509880_96.webp"
+  },
+  {
+	"ids": ["feather-loader"],
+	"name": "Feather Client",
+	"type": "GAME",
+	"status": "UNKNOWN",
+	"tracking": "UNKNOWN",
+	"note": "Does not finish launching Minecraft due to a missing method.",
+	"icon": "https://avatars.githubusercontent.com/u/84419436"
   }
 ]


### PR DESCRIPTION
Trying to run Feather Client with Quilt just causes Feather's blank loading window to remain on the screen until closed

---
See preview on Cloudflare Pages: https://preview-265.quiltmc-org.pages.dev