### PR TITLE
Javadocs index page example

### DIFF
--- a/src/pages/en/dev/javadocs.mdx
+++ b/src/pages/en/dev/javadocs.mdx
@@ -1,0 +1,14 @@
+---
+permalink: /dev/javadocs
+title: Javadoc Index
+description: A list of all quilt javadocs
+layout: /src/layouts/Page.astro
+---
+
+## Quilt Loader
+
+## Quilt Config
+
+## Quilt Parsers
+
+etc etc

--- a/src/pages/en/usage/index.mdx
+++ b/src/pages/en/usage/index.mdx
@@ -17,3 +17,4 @@ layout: /src/layouts/Page.astro
 - [Quilt Developer Wiki](https://wiki.quiltmc.org)
 - [Quilt Maven Repository](https://maven.quiltmc.org)
 - [Quilt Template Mod](https://github.com/QuiltMC/quilt-template-mod)
+- [Quilt Javadocs](/en/dev/javadocs)


### PR DESCRIPTION
I'll add js to make it display the versions under the projects and possibly a way to navigate easier.

---
Preview: https://preview-281-quiltmc-org.quiltmc.workers.dev/